### PR TITLE
Backup Entity 추가

### DIFF
--- a/src/main/java/com/sb11/hr_bank/backup/entity/Backup.java
+++ b/src/main/java/com/sb11/hr_bank/backup/entity/Backup.java
@@ -1,0 +1,54 @@
+package com.sb11.hr_bank.backup.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.Instant;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Backup extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY) // auto_increment
+  private Long id;
+
+  @Column(name = "worker", length = 20, nullable = false)
+  private String worker;
+
+  @Column(name = "startedAt", nullable = false)
+  private Instant startedAt;
+
+  @Column(name = "endedAt", nullable = false)
+  private Instant endedAt;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", length = 20)
+  private Status status;
+
+  @Column(name = "fileId")
+  private Long fileId;
+
+  public enum Status {
+    IN_PROGRESS("진행중"), COMPLETED("완료"), FAILED("실패"), SKIPPED("건너뜀");
+
+    private final String description;
+
+    Status(String description) {
+      this.description = description;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+  }
+}
+// 데이터 백업 관리
+// 데이터 백업한 ID, 작업자(IP주소), 백업을 시작한 시간, 백업이 완료된 시간, 상태, 파일 ID(fileId)
+// ID는 BaseEntity
+// 상태는 enum타입(IN_PROGRESS(진행중), COMPLETED(완료), FAILED(실패))

--- a/src/main/java/com/sb11/hr_bank/backup/entity/Backup.java
+++ b/src/main/java/com/sb11/hr_bank/backup/entity/Backup.java
@@ -4,15 +4,21 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import java.time.Instant;
 import lombok.Getter;
+import lombok.Setter;
 
 @Entity
-@Getter
-public class Backup extends BaseEntity {
+@Table(name = "backup")
+@Getter @Setter
+public class Backup { // extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY) // auto_increment
@@ -21,34 +27,31 @@ public class Backup extends BaseEntity {
   @Column(name = "worker", length = 20, nullable = false)
   private String worker;
 
-  @Column(name = "startedAt", nullable = false)
+  @Column(name = "started_at", nullable = false)
   private Instant startedAt;
 
-  @Column(name = "endedAt", nullable = false)
+  @Column(name = "ended_at", nullable = false)
   private Instant endedAt;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "status", length = 20)
-  private Status status;
+  private BackupStatus status;
 
-  @Column(name = "fileId")
-  private Long fileId;
+  // 1개의 백업에는 1개의 파일(1:1)
+  // Backup은 fileId를 참조하여 어떤 File인지 알아야함(단방향)
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "file_id")
+  private File fileId;
 
-  public enum Status {
-    IN_PROGRESS("진행중"), COMPLETED("완료"), FAILED("실패"), SKIPPED("건너뜀");
-
-    private final String description;
-
-    Status(String description) {
-      this.description = description;
-    }
-
-    public String getDescription() {
-      return description;
-    }
+  private Backup(String worker, Instant startedAt, Instant endedAt, BackupStatus status, File fileId) {
+    this.worker = worker;
+    this.startedAt = Instant.now();
+    this.endedAt = Instant.now();
+    this.status = status;
+    this.fileId = fileId;
   }
 }
 // 데이터 백업 관리
 // 데이터 백업한 ID, 작업자(IP주소), 백업을 시작한 시간, 백업이 완료된 시간, 상태, 파일 ID(fileId)
-// ID는 BaseEntity
-// 상태는 enum타입(IN_PROGRESS(진행중), COMPLETED(완료), FAILED(실패))
+// ID는 추후에 BaseEntity ?
+// 상태는 enum타입

--- a/src/main/java/com/sb11/hr_bank/backup/entity/BackupStatus.java
+++ b/src/main/java/com/sb11/hr_bank/backup/entity/BackupStatus.java
@@ -1,0 +1,13 @@
+package com.sb11.hr_bank.backup.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BackupStatus {
+  IN_PROGRESS("진행중"), COMPLETED("완료"), FAILED("실패"), SKIPPED("건너뜀");
+
+  private final String description;
+}
+// Backup의 상태, 진행중(처리), 완료, 실패, 건너뜀(변경 이력이 없을 시)


### PR DESCRIPTION
Backup Entity를 추가하였습니다.
Backup 내의 enum 타입의 status 필드는 BackupStatus.java로 따로 분리하였습니다.

요구사항에서 변경된 이력이 없을 시에 건너뜀이라는 status가 있어
SKIPPED("건너뜀")도 같이 추가했는데 괜찮을까요 ?