### PR TITLE
feat: FileController API 구현 (파일 업로드 및 메타데이터 조회)

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/file/controller/FileController.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/controller/FileController.java
@@ -1,8 +1,15 @@
 package com.sb11.hr_bank.domain.file.controller;
 
+import com.sb11.hr_bank.domain.file.dto.FileResponse;
+import com.sb11.hr_bank.domain.file.entity.FileEntity;
 import com.sb11.hr_bank.domain.file.service.FileService;
+import java.io.IOException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/files")
@@ -11,5 +18,27 @@ public class FileController {
 
   public FileController(FileService fileService) {
     this.fileService = fileService;
+  }
+
+  //파일 업로드 API
+  @PostMapping
+  public ResponseEntity<FileResponse> uploadFile(
+      @RequestParam("file") MultipartFile file) throws IOException {
+    //파일 저장 후 ID 반환
+    Long fileId = fileService.uploadFile(file);
+
+    //저장된 파일 메타데이터 조회
+    FileEntity fileEntity = fileService.getFileMetadata(fileId);
+
+    //응답용 DTO 변환
+    FileResponse response = new FileResponse(
+        fileEntity.getId(),
+        fileEntity.getName(),
+        fileEntity.getContentType(),
+        fileEntity.getSize()
+    );
+
+    //결과 반환
+    return ResponseEntity.ok(response);
   }
 }


### PR DESCRIPTION
- **파일 업로드 API (`POST /api/files`)**: `MultipartFile`을 통해 전달받은 파일을 서비스 계층에 전달하고, 생성된 파일 정보를 `FileResponse` DTO로 반환합니다.

##  코드리뷰 요청 사항

파일/위치: FileController.java

요청 내용: MultipartFile을 컨트롤러에서 받아 처리하는 전반적인 구조에 대해 피드백을 받고 싶습니다. 특히 CodeRabbit이 조언해준 대로 IOException 등을 전역 예외 처리(@ControllerAdvice)로 빼서 관리하는 것이 실무적으로 더 권장되는 방식인지 궁금합니다.

고민한 점: 컨트롤러 내부에서 예외를 직접 잡는 것과 전역으로 위임하는 것 사이의 유지보수 효율성에 대해 고민했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 파일 업로드 기능을 위한 새로운 REST API 엔드포인트(`POST /api/files`)가 추가되었습니다. 사용자는 이 엔드포인트를 통해 파일을 업로드하고 업로드된 파일의 메타데이터(파일 ID, 파일명, 콘텐츠 타입, 파일 크기)를 응답으로 받을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->