### PR TITLE
refactor: 파일 업로드 로직 최적화 및 반환 타입 변경

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/file/controller/FileController.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/controller/FileController.java
@@ -24,11 +24,9 @@ public class FileController {
   @PostMapping
   public ResponseEntity<FileResponse> uploadFile(
       @RequestParam("file") MultipartFile file) throws IOException {
-    //파일 저장 후 ID 반환
-    Long fileId = fileService.uploadFile(file);
 
-    //저장된 파일 메타데이터 조회
-    FileEntity fileEntity = fileService.getFileMetadata(fileId);
+    //파일 저장 후 엔티티 반환
+    FileEntity fileEntity = fileService.uploadFile(file);
 
     //응답용 DTO 변환
     FileResponse response = new FileResponse(
@@ -38,7 +36,7 @@ public class FileController {
         fileEntity.getSize()
     );
 
-    //결과 반환
+    //실행 결과 반환
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
@@ -26,7 +26,7 @@ public class FileService {
 
   //파일 업로드 클래스 (로컬 디스크 저장 및 DB 기록)
   @Transactional
-  public Long uploadFile(MultipartFile file) throws IOException {
+  public FileEntity uploadFile(MultipartFile file) throws IOException {
     //빈 파일 검증
     if (file == null || file.isEmpty()) {
       throw new IllegalArgumentException("업로드 된 파일이 없습니다.");
@@ -59,7 +59,7 @@ public class FileService {
     FileEntity savedEntity = fileRepository.save(fileEntity);
 
     //저장된 파일의 ID 리턴
-    return savedEntity.getId();
+    return fileRepository.save(fileEntity);
   }
 
   //파일 메타데이터 단건 조회

--- a/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
@@ -55,9 +55,6 @@ public class FileService {
         savedPath
     );
 
-    //DB에 정보 저장 후, 저장된 결과물 반환
-    FileEntity savedEntity = fileRepository.save(fileEntity);
-
     //저장된 파일의 ID 리턴
     return fileRepository.save(fileEntity);
   }


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- `FileService.uploadFile` 메서드의 반환 타입을 `Long`에서 `FileEntity`로 변경
- `FileController`에서 파일 업로드 후 메타데이터를 다시 조회하던 불필요한 로직을 제거하여 DB 단일 쿼리로 최적화.

## 🔗 관련 이슈
- Resolves: 

## 🤔 리뷰어에게 부탁할 사항
- `uploadFile` 호출 시 ID가 아닌 `FileEntity` 객체를 바로 반환받으실 수 있으니 직원 프로필 연동 작업 시 참고해 주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 파일 업로드 흐름 단순화: 업로드 처리 결과를 직접 활용하도록 변경해 불필요한 메타데이터 조회 호출을 제거했습니다.
  * 성능 및 응답 일관성 향상: 호출 횟수 감소로 처리 지연이 줄고 응답에 파일 정보가 즉시 포함됩니다.
  * 공개 인터페이스 변경 없음: 외부 사용법에는 영향이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->