### PR TITLE
feat: 공통 CursurPageResponseDto 추가

### DIFF
--- a/src/main/java/com/sb11/hr_bank/global/dto/PageResponse.java
+++ b/src/main/java/com/sb11/hr_bank/global/dto/PageResponse.java
@@ -14,7 +14,7 @@ public record PageResponse<T>(
     boolean hasNext
 ) {
 
-  static <T> PageResponse<T> fromPage(Page<T> page){
+  public static <T> PageResponse<T> fromPage(Page<T> page){
 
     return new PageResponse<>(
 
@@ -29,7 +29,7 @@ public record PageResponse<T>(
 
 
   }
-  static <T> PageResponse<T> fromSlice(Slice<T> slice, String nextCursor, Long nextIdAfter){
+  public static <T> PageResponse<T> fromSlice(Slice<T> slice, String nextCursor, Long nextIdAfter){
 
     return new PageResponse<>(
 

--- a/src/main/java/com/sb11/hr_bank/global/dto/PageResponse.java
+++ b/src/main/java/com/sb11/hr_bank/global/dto/PageResponse.java
@@ -1,0 +1,46 @@
+package com.sb11.hr_bank.global.dto;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
+
+public record PageResponse<T>(
+
+    List<T> content,
+    String nextCursor,
+    Long nextIdAfter,
+    int size,
+    Long totalElements,
+    boolean hasNext
+) {
+
+  static <T> PageResponse<T> fromPage(Page<T> page){
+
+    return new PageResponse<>(
+
+        page.getContent(),
+        null,
+        null,
+        page.getSize(),
+        page.getTotalElements(),
+        page.hasNext()
+
+    );
+
+
+  }
+  static <T> PageResponse<T> fromSlice(Slice<T> slice, String nextCursor, Long nextIdAfter){
+
+    return new PageResponse<>(
+
+        slice.getContent(),
+        nextCursor,
+        nextIdAfter,
+        slice.getSize(),
+        null,
+        slice.hasNext()
+    );
+  }
+
+
+}


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- 모든 목록 제공 api의 ResponseDto 필드가 같으므로, global에 추가했습니다!

## 🔗 관련 이슈
- Resolves: #이슈번호

## 🤔 리뷰어에게 부탁할 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 새로운 페이지네이션 응답 형식을 도입했습니다. 커서 기반(다음 커서 및 다음 아이디)과 오프셋 기반(페이지 크기·총 항목 수) 정보를 함께 제공하여 대규모 데이터 조회 시 탐색이 용이하고 성능 및 사용자 경험이 향상됩니다. 응답에 다음 페이지 존재 여부도 포함됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->