### PR TITLE
feat: ChangeLog DTO 생성

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/dto/ChangeLogRequestDto.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/dto/ChangeLogRequestDto.java
@@ -1,5 +1,50 @@
 package com.sb11.hr_bank.domain.changelogs.dto;
 
+import com.sb11.hr_bank.domain.changelogs.entity.ChangeLogType;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.List;
+
 public class ChangeLogRequestDto {
+  // 생성 요청 DTO
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Create {
+    private Long employeeId;
+    private ChangeLogType type;
+    private String memo;
+    private List<Detail> details;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Detail {
+      private String propertyName;
+      private String before;
+      private String after;
+    }
+  }
+
+  // 검색 요청 DTO + 커서 페이징
+  @Getter @Setter
+  public static class Search {
+    private Long employeeId;
+    private String memo;
+    private String ipAddress;
+    private ChangeLogType type;
+    private Instant startDate;
+    private Instant endDate;
+
+    // 이전 페이지 마지막 요소 ID (커서)
+    private Long lastId;
+    // ipAddreee or createdAt (기본값)
+    private String sortBy;
+    private Integer size = 10;
+  }
+
 
 }

--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/dto/ChangeLogRequestDto.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/dto/ChangeLogRequestDto.java
@@ -41,7 +41,7 @@ public class ChangeLogRequestDto {
 
     // 이전 페이지 마지막 요소 ID (커서)
     private Long lastId;
-    // ipAddreee or createdAt (기본값)
+    // ipAddress or createdAt (기본값)
     private String sortBy;
     private Integer size = 10;
   }

--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/dto/ChangeLogResponseDto.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/dto/ChangeLogResponseDto.java
@@ -1,5 +1,42 @@
 package com.sb11.hr_bank.domain.changelogs.dto;
 
+import com.sb11.hr_bank.domain.changelogs.entity.ChangeLogType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.List;
+
 public class ChangeLogResponseDto {
+
+  // 목록 조회용 DTO
+  @Getter
+  @Builder
+  public static class ListInfo {
+    private Long id;
+    private Long employeeId;
+    private ChangeLogType type;
+    private String memo;
+    private String ipAddress;
+    private Instant createdAt;
+
+  }
+
+  // 상세 조회용 DTO
+  @Getter
+  @Builder
+  public static class DetailItem {
+
+    private Long id;
+    private List<DetailItem> details;
+
+    @Getter
+    @Builder
+    public static class DetailItem{
+      private String propertyName;
+      private String before;
+      private String after;
+    }
+  }
 
 }

--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/dto/ChangeLogResponseDto.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/dto/ChangeLogResponseDto.java
@@ -25,7 +25,7 @@ public class ChangeLogResponseDto {
   // 상세 조회용 DTO
   @Getter
   @Builder
-  public static class DetailItem {
+  public static class DetailInfo {
 
     private Long id;
     private List<DetailItem> details;

--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/entity/ChangeDetailLog.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/entity/ChangeDetailLog.java
@@ -1,16 +1,16 @@
 package com.sb11.hr_bank.domain.changelogs.entity;
 
+import com.sb11.hr_bank.global.base.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
 
 @Entity
 @Table(name = "change_detail_logs")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChangeDetailLog {
+public class ChangeDetailLog extends BaseEntity{
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/entity/ChangeDetailLog.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/entity/ChangeDetailLog.java
@@ -22,8 +22,8 @@ public class ChangeDetailLog {
   private ChangeLog changeLog;
 
   // 어떤 항목이 변경되었는지
-  @Column(name = "column_name", nullable = false, length = 50)
-  private String columnName;
+  @Column(name = "property_name", nullable = false, length = 30)
+  private String propertyName;
 
   // 변경 전 데이터
   @Column(name = "before", columnDefinition = "TEXT")
@@ -34,8 +34,8 @@ public class ChangeDetailLog {
   private String after;
 
   @Builder
-  public ChangeDetailLog(String columnName, String before, String after) {
-    this.columnName = columnName;
+  public ChangeDetailLog(String propertyName, String before, String after) {
+    this.propertyName = propertyName;
     this.before = before;
     this.after = after;
 

--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/entity/ChangeLog.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/entity/ChangeLog.java
@@ -1,16 +1,10 @@
 package com.sb11.hr_bank.domain.changelogs.entity;
 
-import com.sb11.hr_bank.employee.Employee;
+import com.sb11.hr_bank.domain.employee.entity.Employee;
 import com.sb11.hr_bank.global.base.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.AuditingEntityListener;
+import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,7 +12,6 @@ import java.util.List;
 @Table(name = "change_logs")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 public class ChangeLog extends BaseEntity {
 
   @Id
@@ -28,13 +21,14 @@ public class ChangeLog extends BaseEntity {
   // Employee Entity 연결
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "employee_id", nullable = false)
-  private Employee employee;
+  private Employee employeeId;
 
   // @Enumerated(EnumType.STRING) - DB 확인 후 어노테이션 삭제 + 컨버터 클래스 생성
-  @Column(nullable = false, length = 20)
+  @Convert(converter = ChangeLogTypeConverter.class)
+  @Column(name = "type", nullable = false, length = 20)
   private ChangeLogType type;
 
-  @Column(columnDefinition = "TEXT")
+  @Column(name = "memo", columnDefinition = "TEXT")
   private String memo;
 
   @Column(name = "ip_address", nullable = false, length = 20)
@@ -44,8 +38,8 @@ public class ChangeLog extends BaseEntity {
   private List<ChangeDetailLog> details = new ArrayList<>();
 
   @Builder
-  public ChangeLog(Employee employee, ChangeLogType type, String memo, String ipAddress) {
-    this.employee = employee;
+  public ChangeLog(Employee employeeId, ChangeLogType type, String memo, String ipAddress) {
+    this.employeeId = employeeId;
     this.type = type;
     this.memo = memo;
     this.ipAddress = ipAddress;

--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/repository/ChangeDetailLogRepository.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/repository/ChangeDetailLogRepository.java
@@ -2,9 +2,9 @@ package com.sb11.hr_bank.domain.changelogs.repository;
 
 import com.sb11.hr_bank.domain.changelogs.entity.ChangeDetailLog;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
+import java.util.List;
+
 public interface ChangeDetailLogRepository extends JpaRepository<ChangeDetailLog,Long> {
-
+  List<ChangeDetailLog> findByChangeLogId(Long changeLogId);
 }

--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/repository/ChangeLogRepository.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/repository/ChangeLogRepository.java
@@ -1,14 +1,24 @@
 package com.sb11.hr_bank.domain.changelogs.repository;
 
 import com.sb11.hr_bank.domain.changelogs.entity.ChangeLog;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-import java.time.Instant;
-import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-@Repository
+import java.time.Instant;
+
+
 public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
-  // Backup 파트에서 요청. 특정 Instant 이후 데이터가 있는지 확인하는 코드
+  // Backup 파트에서 요청. lastBackupTime 이후 생성된 데이터가 있는지 확인하는 코드
   boolean existsByCreatedAtAfter(Instant lastBackupTime);
+
+  // 커서 기반 페이징 쿼리
+  // Where c.id < :lastId(커서 역할. 마지막으로 본 데이터의 ID보다 과거의 데이터 가져오는 필터링)
+  // ORDER BY c,id DESC (최근 데이터부터 보여주기 위해 내림차순으로 정렬함.)
+  @Query("SELECT c FROM ChangeLog c Where c.id < :lastId ORDER BY c.id DESC")
+  // @Param("lastId") : 메서드 파라미터로 들어온 `lastId`값을 뭐리문의 `:lastId`자리에 넣어줌
+  Slice<ChangeLog> findByCursorPaging(@Param("lastId") Long lastId, Pageable pageable);
 
 }

--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/repository/ChangeLogRepository.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/repository/ChangeLogRepository.java
@@ -15,10 +15,14 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
   boolean existsByCreatedAtAfter(Instant lastBackupTime);
 
   // 커서 기반 페이징 쿼리
+  // 첫 페이지용 페이징 쿼리
+  @Query("SELECT c FROM ChangeLog c ORDER BY c.id DESC")
+  Slice<ChangeLog> findFirstPage(Pageable pageable);
+
   // Where c.id < :lastId(커서 역할. 마지막으로 본 데이터의 ID보다 과거의 데이터 가져오는 필터링)
-  // ORDER BY c,id DESC (최근 데이터부터 보여주기 위해 내림차순으로 정렬함.)
+  // ORDER BY c.id DESC (최근 데이터부터 보여주기 위해 내림차순으로 정렬함.)
   @Query("SELECT c FROM ChangeLog c Where c.id < :lastId ORDER BY c.id DESC")
-  // @Param("lastId") : 메서드 파라미터로 들어온 `lastId`값을 뭐리문의 `:lastId`자리에 넣어줌
+  // @Param("lastId") : 메서드 파라미터로 들어온 `lastId`값을 쿼리문의 `:lastId`자리에 넣어줌
   Slice<ChangeLog> findByCursorPaging(@Param("lastId") Long lastId, Pageable pageable);
 
 }


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- entity의 ChangeDetailLog 클래스 DB 확인 후 column_name -> property_name으로 변경
- repository의 ChangeDetailLogRepository 추가
- repository의 ChangeLogRepository에서 기존 @Repository 어노테이션 삭제 후 @Query로 구조 변경(커서 기반 페이징 기능)
- DTO 작성

## 🔗 관련 이슈
- Resolves: 

## 🤔 리뷰어에게 부탁할 사항
- @Jeongyun-Choi62  before / after 수정 후 property_name 부분도 발견하여 수정 완료했습니다.
- @DonToong2  Repository 부분에서 ChangeDetailLogRepository가 추가되어 이 부분도 기존에 Instant로 백업파트와 비교하는 코드 요청주셨던 부분 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 변경 이력 생성 및 검색 페이로드 확장: 생성 시 상세 항목 입력 지원, 검색에 직원/메모/IP/유형/기간/정렬/페이지 사이즈 옵션 추가
  * 커서 기반 페이지네이션으로 대량 조회 성능 개선
  * 변경 이력 리스트/상세 뷰 개선: 항목별 전/후 값 표시 및 상세 구조 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->