### PR TITLE
feat: 파일 및 메타데이터 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/file/controller/FileController.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/controller/FileController.java
@@ -4,10 +4,12 @@ import com.sb11.hr_bank.domain.file.dto.FileResponse;
 import com.sb11.hr_bank.domain.file.entity.FileEntity;
 import com.sb11.hr_bank.domain.file.service.FileService;
 import com.sb11.hr_bank.domain.file.storage.FileStorage;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -52,5 +54,13 @@ public class FileController {
     FileEntity fileEntity = fileService.getFileMetadata(id);
 
     return fileStorage.download(fileEntity);
+  }
+
+  //파일 삭제
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteFile(
+      @PathVariable("id") Long id) {
+    fileService.deleteFile(id);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
@@ -73,6 +73,7 @@ public class FileService {
     return savedEntity;
   }
 
+  //파일 저장 공용 메서드
   private FileEntity saveMetadata(String name, String contentType, Long size) {
     //저장할 폴더가 없을 시 생성
     File directory = rootPath.toFile();
@@ -89,5 +90,24 @@ public class FileService {
 
   private Path getAbsolutePath(Long id) {
     return rootPath.resolve(id.toString()).toAbsolutePath();
+  }
+
+  //파일 삭제 메서드
+  @Transactional
+  public void deleteFile(Long id) {
+    //DB 메타데이터 조회
+    FileEntity fileEntity = getFileMetadata(id);
+
+    //로컬 디스크 파일 삭제
+    Path destPath = getAbsolutePath(fileEntity.getId());
+
+    try {
+      Files.deleteIfExists(destPath);
+    } catch (IOException e) {
+      throw new BusinessException(ErrorCode.FILE_STORAGE_ERROR);
+    }
+
+    //DB 메타데이터 삭제
+    fileRepository.delete(fileEntity);
   }
 }


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- **파일 삭제 로직(deleteFile) 구현:** FileService에 물리 파일(로컬 디스크)과 DB 메타데이터를 트랜잭션 내에서 동시 삭제하는 기능 추가
- **안전한 삭제 처리:** Files.deleteIfExists()를 활용하여 물리 파일이 누락된 예외 상황에서도 DB 삭제가 정상적으로 처리되도록 안정성 확보
- **삭제 API 엔드포인트 추가:** FileController에 DELETE /api/files/{id} 엔드포인트 추가 (성공 시 204 No Content 반환)

## 🔗 관련 이슈
- Resolves: #이슈번호

## 🤔 리뷰어에게 부탁할 사항
- 유저 생성 실패 시 더미 프로필 사진 삭제 기능 구현했습니다! try-catch 블록의 에러 처리 부분에서 deleteFile(id) 메서드를 호출해 주시면 롤백됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 파일 삭제 기능 추가: 파일 ID를 통해 저장된 파일을 삭제할 수 있는 새로운 REST API 엔드포인트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->