### PR TITLE
fix: 파일 삭제 로직 보안 및 트랙잭션 정합성 문제 해결

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/file/controller/FileController.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/controller/FileController.java
@@ -55,12 +55,4 @@ public class FileController {
 
     return fileStorage.download(fileEntity);
   }
-
-  //파일 삭제
-  @DeleteMapping("/{id}")
-  public ResponseEntity<Void> deleteFile(
-      @PathVariable("id") Long id) {
-    fileService.deleteFile(id);
-    return ResponseEntity.noContent().build();
-  }
 }

--- a/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
@@ -9,10 +9,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j //로그 사용을 위한 어노테이션
 @Service
 @Transactional(readOnly = true)
 public class FileService {
@@ -101,13 +105,21 @@ public class FileService {
     //로컬 디스크 파일 삭제
     Path destPath = getAbsolutePath(fileEntity.getId());
 
-    try {
-      Files.deleteIfExists(destPath);
-    } catch (IOException e) {
-      throw new BusinessException(ErrorCode.FILE_STORAGE_ERROR);
-    }
-
     //DB 메타데이터 삭제
     fileRepository.delete(fileEntity);
+
+    //DB 트랙잭션이 커밋된 이후 로컬 파일 삭제
+    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+      @Override
+      public void afterCommit() {
+        try {
+          Files.deleteIfExists(destPath);
+          log.info("로컬 파일 삭제 성공: {}", destPath);
+        } catch (IOException e) {
+          //DB 커밋이 끝났으므로 롤백 불가, 에러 로그 남김
+          log.error("로컬 파일 삭제 실패: {}", destPath, e);
+        }
+      }
+    });
   }
 }


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- **보안 강화 (IDOR 취약점 해결):** 권한 없는 사용자가 임의로 파일을 지울 수 없도록 FileController의 외부 노출용 파일 삭제 API를 완전히 제거했습니다.
- **데이터 정합성 보장:** 트랜잭션 롤백 시 DB 레코드는 살아나는데 물리 파일만 지워지는 현상을 막기 위해, TransactionSynchronizationManager를 도입하여 DB 커밋이 완료된 직후(afterCommit)에만 로컬 파일이 지워지도록 순서를 변경했습니다.
## 🔗 관련 이슈
- Resolves: #이슈번호

## 🤔 리뷰어에게 부탁할 사항
- 이전 PR이 머지된 직후, 코드래빗이 지적해 준 취약점 2가지(보안, 삭제 순서)를 보완하기 위해 올리는 후속 PR입니다.
- 외부 삭제 API가 닫혔으므로, 유저 생성 실패 시 더미 프로필 사진을 지우실 때는 컨트롤러를 거치지 마시고 FileService.deleteFile(id)를 내부 로직(catch 문 등)에서 바로 호출해서 사용해 주시면 됩니다! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 파일 삭제 기능이 제거되었습니다. 기존의 파일 삭제 요청은 더 이상 지원되지 않습니다. 파일 업로드 및 다운로드 기능은 정상적으로 작동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->