### PR TITLE
fix: 트랜잭션 롤백 시 더미 파일 누락 문제 해결

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
@@ -122,4 +122,22 @@ public class FileService {
       }
     });
   }
+
+  //더미 파일 정리 메서드(트랙잭션 커밋을 기다리지 않고 로컬 파일 삭제)
+  @Transactional
+  public void cleanupDummyFile(Long id) {
+    FileEntity fileEntity = getFileMetadata(id);
+    Path destPath = getAbsolutePath(fileEntity.getId());
+
+    //커밋을 기다리지 않고 로컬 파일 삭제
+    try {
+      Files.deleteIfExists(destPath);
+      log.info("에러 복구: 롤백 대비 더미 파일 삭제 완료: {}", destPath);
+    } catch (IOException e) {
+      log.error("에러 복구: 더미 파일 삭제 실패(수동 확인 필요): {}", destPath, e);
+    }
+
+    //DB 메타데이터 삭제
+    fileRepository.delete(fileEntity);
+  }
 }

--- a/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
@@ -128,16 +128,18 @@ public class FileService {
   public void cleanupDummyFile(Long id) {
     FileEntity fileEntity = getFileMetadata(id);
     Path destPath = getAbsolutePath(fileEntity.getId());
-
+    
     //커밋을 기다리지 않고 로컬 파일 삭제
     try {
+      //로컬 파일 삭제 시도
       Files.deleteIfExists(destPath);
       log.info("에러 복구: 롤백 대비 더미 파일 삭제 완료: {}", destPath);
+
+      //로컬 파일 삭제 성공 시 DB 메타데이터 삭제
+      fileRepository.delete(fileEntity);
     } catch (IOException e) {
+      //에러 발생 시 DB 삭제 코드는 실행 되지 않음
       log.error("에러 복구: 더미 파일 삭제 실패(수동 확인 필요): {}", destPath, e);
     }
-
-    //DB 메타데이터 삭제
-    fileRepository.delete(fileEntity);
   }
 }


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- **에러 복구 전용 삭제 메서드(cleanupDummyFile) 추가:** 기존 deleteFile의 afterCommit 훅이 롤백 상황에서는 동작하지 않아 디스크에 더미 파일이 남는 잠재적 문제를 해결했습니다.
- **로컬 파일 즉시 삭제:** 트랜잭션 동기화(Commit)를 기다리지 않고 예외 발생 즉시 물리 파일을 지우도록 로직을 분리하여, 타 도메인에서 에러 복구 시 안전하게 호출할 수 있도록 구현했습니다.

## 🔗 관련 이슈
- Resolves: #이슈번호

## 🤔 리뷰어에게 부탁할 사항
- 유저 생성 로직 짜실 때, try-catch의 catch 블록에서 에러 처리하실 때는 deleteFile 대신 새로 만든 **cleanupDummyFile(id)**를 호출해 주세요! 그래야 전체 롤백이 되더라도 파일이 지워집니다.

##  코드리뷰 요청 사항

파일/위치: FileService의 파일 삭제 및 예외 복구 메서드

요청 내용: 현재 로컬 파일 시스템에서 파일을 삭제하는 로직을 구현했습니다. DB 트랜잭션 상황과 물리적 파일의 상태를 맞추기 위해 예외 발생 시 직접 파일을 지워주도록 구현했는데, 실무에서는 이런 더미 파일들을 어떻게 관리하는지(배치 처리인지, 즉각 삭제인지) 조언을 구하고 싶습니다.

고민한 점: 코드래빗 리뷰 등을 거치며 파일 삭제 로직을 다듬었는데, 여전히 파일 I/O 과정에서 권한 문제나 사용 중인 파일 등의 이유로 삭제가 실패할 경우의 처리가 고민됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 더미 파일을 즉시 검사·삭제하고 관련 메타데이터를 함께 정리하는 파일 정리 기능이 추가되었습니다.

* **버그 수정**
  * 실패 시 데이터 일관성을 보호하도록 파일 삭제 흐름의 예외 처리가 개선되었습니다.

* **개선 사항**
  * 파일 관리의 안정성과 정리 속도가 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->