### PR TITLE
feat: 부서 관리 API 명세 최적화 및 페이징 처리

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/department/controller/DepartmentApi.java
+++ b/src/main/java/com/sb11/hr_bank/domain/department/controller/DepartmentApi.java
@@ -13,10 +13,10 @@ import java.util.List;
 public interface DepartmentApi {
 
   @Operation(summary = "부서 등록")
-  ResponseEntity<Void> createDepartment(@RequestBody DepartmentRequest request);
+  ResponseEntity<DepartmentResponse> createDepartment(@RequestBody DepartmentRequest request);
 
   @Operation(summary = "부서 수정")
-  ResponseEntity<Void> updateDepartment(@PathVariable Long id, @RequestBody DepartmentRequest request);
+  ResponseEntity<DepartmentResponse> updateDepartment(@PathVariable Long id, @RequestBody DepartmentRequest request);
 
   @Operation(summary = "부서 삭제")
   ResponseEntity<Void> deleteDepartment(@PathVariable Long id);
@@ -25,5 +25,5 @@ public interface DepartmentApi {
   ResponseEntity<DepartmentResponse> getDepartmentDetail(@PathVariable Long id);
 
   @Operation(summary = "전체 부서 목록 조회")
-  ResponseEntity<Page<DepartmentResponse>> getAllDepartments(Pageable pageable);
+  ResponseEntity<PageResponse<DepartmentResponse>> getAllDepartments();
 }

--- a/src/main/java/com/sb11/hr_bank/domain/department/controller/DepartmentApi.java
+++ b/src/main/java/com/sb11/hr_bank/domain/department/controller/DepartmentApi.java
@@ -13,7 +13,7 @@ import java.util.List;
 public interface DepartmentApi {
 
   @Operation(summary = "부서 등록")
-  ResponseEntity<Long> createDepartment(@RequestBody DepartmentRequest request);
+  ResponseEntity<Void> createDepartment(@RequestBody DepartmentRequest request);
 
   @Operation(summary = "부서 수정")
   ResponseEntity<Void> updateDepartment(@PathVariable Long id, @RequestBody DepartmentRequest request);
@@ -25,5 +25,5 @@ public interface DepartmentApi {
   ResponseEntity<DepartmentResponse> getDepartmentDetail(@PathVariable Long id);
 
   @Operation(summary = "전체 부서 목록 조회")
-  ResponseEntity<List<DepartmentResponse>> getAllDepartments();
+  ResponseEntity<Page<DepartmentResponse>> getAllDepartments(Pageable pageable);
 }

--- a/src/main/java/com/sb11/hr_bank/domain/department/controller/DepartmentController.java
+++ b/src/main/java/com/sb11/hr_bank/domain/department/controller/DepartmentController.java
@@ -7,6 +7,7 @@ import com.sb11.hr_bank.domain.department.service.DepartmentService;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,7 +21,7 @@ public class DepartmentController implements DepartmentApi {
 
   // 부서등록
   @PostMapping // 데이터를 새로 저장할 때 사용
-  public ResponseEntity<Long> createDepartment(@RequestBody DepartmentRequest request) {
+  public ResponseEntity<Void> createDepartment(DepartmentRequest request) {
     // 화면에서 보낸 JSON 데이터를 DTO 바구니에 담아 받음
     // DTO에 담긴 내용을 꺼내 새로운 Entity로 만듬
     Department department = Department.builder()
@@ -29,9 +30,9 @@ public class DepartmentController implements DepartmentApi {
         .createdDate(LocalDate.parse(request.establishmentDate()))
         .build();
 
-    Long savedId = departmentService.save(department);
+    departmentService.save(department);
     // 201 Created 상태코드와 함께 저장된 ID를 반환
-    return ResponseEntity.status(HttpStatus.CREATED).body(savedId);
+    return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
   // 부서수정
@@ -67,9 +68,8 @@ public class DepartmentController implements DepartmentApi {
 
   // 전체 목록 조회
   @GetMapping
-  public ResponseEntity<List<Department>> getAllDepartments() {
-    List<Department> departments = departmentService.findAll();
-    // 리스트를 담아 200 OK와 함께 전송
-    return ResponseEntity.ok(departments);
+  public ResponseEntity<Page<DepartmentResponse>> getAllDepartments(Pageable pageable) {
+    Page<DepartmentResponse> responses = departmentService.findAll(pageable);
+    return ResponseEntity.ok(responses);
   }
 }

--- a/src/main/java/com/sb11/hr_bank/domain/department/controller/DepartmentController.java
+++ b/src/main/java/com/sb11/hr_bank/domain/department/controller/DepartmentController.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+
 @RestController // 이 클래스가 외부 요청을 받는곳
 @RequestMapping("/sb/hrbank/api/departments") // Swagger에 명시된 기본 주소를 설정
 @RequiredArgsConstructor // final이 붙은 서비스를 자동으로 연결
@@ -21,33 +22,33 @@ public class DepartmentController implements DepartmentApi {
 
   // 부서등록
   @PostMapping // 데이터를 새로 저장할 때 사용
-  public ResponseEntity<Void> createDepartment(DepartmentRequest request) {
-    // 화면에서 보낸 JSON 데이터를 DTO 바구니에 담아 받음
-    // DTO에 담긴 내용을 꺼내 새로운 Entity로 만듬
+  public ResponseEntity<DepartmentResponse> createDepartment(@RequestBody DepartmentRequest request) {
     Department department = Department.builder()
         .name(request.departmentName())
         .description(request.departmentDescription())
         .createdDate(LocalDate.parse(request.establishmentDate()))
         .build();
 
-    departmentService.save(department);
-    // 201 Created 상태코드와 함께 저장된 ID를 반환
-    return ResponseEntity.status(HttpStatus.CREATED).build();
+    // 서비스로부터 생성된 부서의 상세 정보를 받음
+    DepartmentResponse response = departmentService.save(department);
+
+    // 201 Created 코드와 생성된 데이터를 함께 반환
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
   // 부서수정
+  @Override
   @PutMapping("/{id}")
-  public ResponseEntity<Void> updateDepartment(@PathVariable Long id, @RequestBody DepartmentRequest request) {
-    // 수정할 데이터를 DTO에서 가져와서 Entity형태로 전환
+  public ResponseEntity<DepartmentResponse> updateDepartment(@PathVariable Long id, @RequestBody DepartmentRequest request) {
     Department updateParam = Department.builder()
         .name(request.departmentName())
         .description(request.departmentDescription())
         .createdDate(LocalDate.parse(request.establishmentDate()))
         .build();
 
-    departmentService.update(id, updateParam);
+    DepartmentResponse response = departmentService.update(id, updateParam);
     // 성공 시 200 OK를 반환
-    return ResponseEntity.ok().build();
+    return ResponseEntity.ok(response);
   }
 
   // 부서삭제
@@ -67,9 +68,10 @@ public class DepartmentController implements DepartmentApi {
   }
 
   // 전체 목록 조회
+  @Override
   @GetMapping
-  public ResponseEntity<Page<DepartmentResponse>> getAllDepartments(Pageable pageable) {
-    Page<DepartmentResponse> responses = departmentService.findAll(pageable);
-    return ResponseEntity.ok(responses);
+  public ResponseEntity<PageResponse<DepartmentResponse>> getAllDepartments() {
+    PageResponse<DepartmentResponse> response = departmentService.findAll();
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/sb11/hr_bank/domain/department/service/DepartmentService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/department/service/DepartmentService.java
@@ -6,9 +6,10 @@ import com.sb11.hr_bank.domain.department.repository.DepartmentRepository;
 import com.sb11.hr_bank.domain.employee.entity.Employee;
 import com.sb11.hr_bank.domain.employee.repository.EmployeeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 
 import java.util.List;
 
@@ -47,7 +48,7 @@ public class DepartmentService {
     }
     // 부서명을 바꾸려고 할 때, 이미 다른 부서에서 쓰고 있는 부서명인지 체크
 
-      department.setName(updateParam.getName());
+    department.setName(updateParam.getName());
     department.setDescription(updateParam.getDescription());
     department.setCreatedDate(updateParam.getCreatedDate());
   }
@@ -78,9 +79,13 @@ public class DepartmentService {
     return DepartmentResponse.from(department, employees);
   }
 
-  public List<Department> findAll() {
+  // 전체 부서 목록 조회 (페이지네이션 적용)
 
-    return departmentRepository.findAll();
+  public Page<DepartmentResponse> findAll(Pageable pageable) {
+        Page<Department> departments = departmentRepository.findAll(pageable);
+
+   return departments.map(dept -> {
+      List<Employee> employees = employeeRepository.findByDepartmentId(dept.getId());
+      return DepartmentResponse.from(dept, employees);
+    });
   }
-  // 리포지토리에게 DB에 있는 모든 부서 정보를 볼수 있게
-}

--- a/src/main/java/com/sb11/hr_bank/domain/department/service/DepartmentService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/department/service/DepartmentService.java
@@ -5,9 +5,10 @@ import com.sb11.hr_bank.domain.department.entity.Department;
 import com.sb11.hr_bank.domain.department.repository.DepartmentRepository;
 import com.sb11.hr_bank.domain.employee.entity.Employee;
 import com.sb11.hr_bank.domain.employee.repository.EmployeeRepository;
+import com.sb11.hr_bank.global.common.dto.PageResponse; // 팀 공통 PageResponse 경로 확인 필요
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,26 +19,27 @@ import java.util.List;
 @Transactional(readOnly = true) // 테이터를 "읽기만" 하는 작업에서 성능 최적화
 
 public class DepartmentService {
+
   private final DepartmentRepository departmentRepository;
   private final EmployeeRepository employeeRepository;
 
   // 부서 등록 기능 구현
 
   @Transactional // 데이터를 저장하므로 "읽기전용"을해제 트랜잭션을 적용
-  public Long save(Department department) {
+
+  public DepartmentResponse save(Department department) {
     if (departmentRepository.existsByName(department.getName())) {
       throw new IllegalArgumentException("이미 존재하는 부서명 입니다");
     } // 입렵한 부서명이 이미 DB에 있는지 확인하고 중복 메세지 구현
+    Department savedDepartment = departmentRepository.save(department);
 
-    return departmentRepository.save(department).getId();
+    return DepartmentResponse.from(savedDepartment, List.of());
   } // 중복이 없으면 DB에 저장
-
 
   // 부서 수정 기능 구현
 
   @Transactional
-  public void update(Long id, Department updateParam) {
-
+  public DepartmentResponse update(Long id, Department updateParam) {
     Department department = departmentRepository.findById(id)
         .orElseThrow(() -> new IllegalArgumentException("해당 부서가 없습니다. id=" + id));
     // 먼저 수정할 부서가 DB에 있는지 확인하고 가져옴
@@ -51,8 +53,12 @@ public class DepartmentService {
     department.setName(updateParam.getName());
     department.setDescription(updateParam.getDescription());
     department.setCreatedDate(updateParam.getCreatedDate());
+
+    List<Employee> employees = employeeRepository.findByDepartmentId(id);
+    return DepartmentResponse.from(department, employees);
   }
-  // Entity의 내용을 새로운 값으로 변경
+
+  // 부서삭제 기능
 
   @Transactional
   public void delete(Long id) {
@@ -68,6 +74,8 @@ public class DepartmentService {
     // 삭제할 부서의 현재 소속된 직원이 없을 때만 실제 삭제 실행
     departmentRepository.delete(department);
   }
+
+  // 부서상세조회 기능
   public DepartmentResponse getDepartmentDetail(Long id) {
     // 요청시 부서 정보를 DB에서 찾음. 없으면 예외 메세지를 보냄
     Department department = departmentRepository.findById(id)
@@ -81,11 +89,13 @@ public class DepartmentService {
 
   // 전체 부서 목록 조회 (페이지네이션 적용)
 
-  public Page<DepartmentResponse> findAll(Pageable pageable) {
-        Page<Department> departments = departmentRepository.findAll(pageable);
-
-   return departments.map(dept -> {
+  public PageResponse<DepartmentResponse> findAll() {
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    Page<Department> departments = departmentRepository.findAll(pageRequest);
+    List<DepartmentResponse> content = departments.map(dept -> {
       List<Employee> employees = employeeRepository.findByDepartmentId(dept.getId());
       return DepartmentResponse.from(dept, employees);
-    });
+    }).getContent();
+    return new PageResponse<>(content, departments);
   }
+}


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
-DepartmentApi 인터페이스 분리
-부서 등록 API 반환 타입을 ResponseEntity<Void>로 변경 
-전체 목록 조회 시 페이지네이션(Pageable) 기능 도입
-부서 상세 조회 시 소속 직원 명단 및 인원수 포함 로직 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **API 변경사항**
  * 부서 생성 API: 응답에 생성된 부서의 상세 정보가 포함된 본문을 반환합니다(이전의 단순 ID 반환에서 변경).
  * 부서 수정 API: 수정 결과로 수정된 부서의 상세 정보를 본문으로 반환합니다(이전의 빈 응답에서 변경).
  * 부서 목록 조회 API: 전체 목록 대신 페이지네이션된 결과(페이징된 응답 포맷)를 반환합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->