### PR TITLE
Backup 도메인 ErrorCode 상태 에러 메시지 활용과 csv 파일 생성 로직 개선

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/backup/entity/Backup.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/entity/Backup.java
@@ -2,6 +2,8 @@ package com.sb11.hr_bank.domain.backup.entity;
 
 import com.sb11.hr_bank.domain.file.entity.FileEntity;
 import com.sb11.hr_bank.global.base.BaseEntity;
+import com.sb11.hr_bank.global.exception.BusinessException;
+import com.sb11.hr_bank.global.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -71,10 +73,10 @@ public class Backup extends BaseEntity {
   public void complete(FileEntity csvFile) {
     // IN_PROGRESS 상태가 아니면 예외
     if (this.status != BackupStatus.IN_PROGRESS) {
-      throw new IllegalStateException("진행 중인 백업만 완료 처리할 수 있습니다.");
+      throw new BusinessException(ErrorCode.BACKUP_NOT_IN_PROGRESS);
     }
     if (csvFile == null) {
-      throw new IllegalArgumentException("백업을 완료하였지만 csvFile이 생성되지 않았습니다.");
+      throw new BusinessException(ErrorCode.BACKUP_REQUIRED_FILE);
     }
     this.file = csvFile;
     this.status = BackupStatus.COMPLETED;
@@ -84,12 +86,12 @@ public class Backup extends BaseEntity {
   // IN_PROGRESS(진행중) 상태-> FAILED 상태로
   public void fail(FileEntity logFile) {
     if (this.status != BackupStatus.IN_PROGRESS) {
-      throw new IllegalStateException("진행 중인 백업만 실패 처리할 수 있습니다.");
+      throw new BusinessException(ErrorCode.BACKUP_NOT_IN_PROGRESS);
     }
-    if (logFile == null) {
-      throw new IllegalArgumentException("백업을 완료하였지만 logFile이 생성되지 않았습니다.");
+    // NPE 방지
+    if (logFile != null) {
+      this.file = logFile;
     }
-    this.file = logFile;
     this.status = BackupStatus.FAILED;
     this.endedAt = Instant.now();
   }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BackupTxService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BackupTxService.java
@@ -4,7 +4,8 @@ import com.sb11.hr_bank.domain.backup.entity.Backup;
 import com.sb11.hr_bank.domain.backup.repository.BackupRepository;
 import com.sb11.hr_bank.domain.file.entity.FileEntity;
 import com.sb11.hr_bank.domain.file.service.FileService;
-import java.util.NoSuchElementException;
+import com.sb11.hr_bank.global.exception.BusinessException;
+import com.sb11.hr_bank.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -27,7 +28,7 @@ public class BackupTxService {
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void complete(Long backupId, FileEntity csvFile) {
     Backup backup = backupRepository.findById(backupId).orElseThrow(
-        () -> new NoSuchElementException("존재하지 않는 백업입니다. id : " + backupId)
+        () -> new BusinessException(ErrorCode.BACKUP_NOT_FOUND)
     );
 
     backup.complete(csvFile);
@@ -36,9 +37,11 @@ public class BackupTxService {
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void fail(Long backupId, FileEntity logFile) {
     Backup backup = backupRepository.findById(backupId).orElseThrow(
-        () -> new NoSuchElementException("존재하지 않는 백업입니다. id : " + backupId)
+        () -> new BusinessException(ErrorCode.BACKUP_NOT_FOUND)
     );
-    
+
+    // TODO 추후 실패시 만들었던 파일 삭제로직 호출하기
+
     backup.fail(logFile);
 
   }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BackupTxService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BackupTxService.java
@@ -25,6 +25,7 @@ public class BackupTxService {
     return backupRepository.save(backup).getId();
   }
 
+  // 백업 데이터 생성 성공 시
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void complete(Long backupId, FileEntity csvFile) {
     Backup backup = backupRepository.findById(backupId).orElseThrow(
@@ -34,13 +35,12 @@ public class BackupTxService {
     backup.complete(csvFile);
   }
 
+  // 백업 실패 시
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void fail(Long backupId, FileEntity logFile) {
     Backup backup = backupRepository.findById(backupId).orElseThrow(
         () -> new BusinessException(ErrorCode.BACKUP_NOT_FOUND)
     );
-
-    // TODO 추후 실패시 만들었던 파일 삭제로직 호출하기
 
     backup.fail(logFile);
 

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -70,7 +70,7 @@ public class BasicBackupService implements BackupService {
       // 144,EMP-2026-21410784000001,정채원,정채원45@gmail.com,백엔드 개발팀33,테크 리드,2025-09-10,ACTIVE
 
       // 사원 전체 데이터를 호출
-      List<Employee> employees = employeeRepository.findAll();
+      List<Employee> employees = employeeRepository.findAllWithDepartment();
 
       // 직원의 입사일(hireDate)을 YYYY-MM-DD의 형태로 변환
       // YYYY는 목요일을 기준으로 연도가 작년, 내년이 될 수 있음, yyyy는 정상적으로 연도 출력
@@ -115,6 +115,12 @@ public class BasicBackupService implements BackupService {
 
       // 백업 실패(FAILED 상태)
       backupTxService.fail(backupId, file);
+
+      // 백업 최종 실패 시 CSV파일이 남아있을 경우 삭제
+      if (file != null) {
+        // TODO 추후 실패시 만들었던 파일 삭제로직 호출하기
+      }
+
     }
   }
 

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -151,8 +151,9 @@ public class BasicBackupService implements BackupService {
       return "";
     }
 
-    // 따옴표, 줄바꿈, 쉼표 공백으로 처리
+    // 따옴표, 줄바꿈, 쉼표, \r(윈도우 계열 데이터에서 \r이 남을 수 있음)를 공백으로 처리
     value = value.replace("\"", " ");
+    value = value.replace("\r", " ");
     value = value.replace("\n", " ");
     value = value.replace(",", " ");
 

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -88,12 +88,12 @@ public class BasicBackupService implements BackupService {
       for (Employee employee : employees) {
         sb.append(employee.getId()).append(",")
             .append(employee.getEmployeeNumber()).append(",")
-            .append(employee.getName()).append(",")
-            .append(employee.getEmail()).append(",")
-            .append(employee.getDepartment().getName()).append(",")
-            .append(employee.getPosition()).append(",")
-            .append(employee.getHireDate().toString()).append(",")
-            .append(employee.getEmployeeStatus().toString()).append("\n");
+            .append(escape(employee.getName())).append(",")
+            .append(escape(employee.getEmail())).append(",")
+            .append(escape(employee.getDepartment().getName())).append(",")
+            .append(escape(employee.getPosition())).append(",")
+            .append(employee.getHireDate().format(formatter)).append(",")
+            .append(employee.getEmployeeStatus()).append("\n");
       }
 
       // CSV 파일로 사원 백업 데이터를 CSV 파일로 변환
@@ -143,5 +143,19 @@ public class BasicBackupService implements BackupService {
         );
 
     return BackupResponse.from(backup);
+  }
+
+  // csv 입력값 특수문자 처리(줄바꿈, 쉼표, 따옴표 등 처리)
+  private String escape(String value) {
+    if (value == null) {
+      return "";
+    }
+
+    // 따옴표, 줄바꿈, 쉼표 공백으로 처리
+    value = value.replace("\"", " ");
+    value = value.replace("\n", " ");
+    value = value.replace(",", " ");
+
+    return value;
   }
 }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -6,12 +6,17 @@ import com.sb11.hr_bank.domain.backup.entity.Backup;
 import com.sb11.hr_bank.domain.backup.entity.BackupStatus;
 import com.sb11.hr_bank.domain.backup.repository.BackupRepository;
 import com.sb11.hr_bank.domain.changelogs.repository.ChangeLogRepository;
+import com.sb11.hr_bank.domain.employee.entity.Employee;
+import com.sb11.hr_bank.domain.employee.repository.EmployeeRepository;
 import com.sb11.hr_bank.domain.file.entity.FileEntity;
-import com.sb11.hr_bank.domain.file.repository.FileRepository;
 import com.sb11.hr_bank.domain.file.service.FileService;
 import com.sb11.hr_bank.global.dto.PageResponse;
+import com.sb11.hr_bank.global.exception.BusinessException;
+import com.sb11.hr_bank.global.exception.ErrorCode;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -26,7 +31,7 @@ public class BasicBackupService implements BackupService {
 
   private final BackupRepository backupRepository;
   private final ChangeLogRepository changeLogRepository;
-  private final FileRepository fileRepository;
+  private final EmployeeRepository employeeRepository;
 
   private final FileService fileService;
   private final BackupTxService backupTxService;
@@ -59,11 +64,40 @@ public class BasicBackupService implements BackupService {
 
     try {
       // 정상적으로 백업 성공
-      // CSV 파일 생성, CSV 파일을 저장, 성공 상태로 전환
 
-      // CSV 파일로 백업 데이터를 생성
-      String csv = "";
-      byte[] csvData = csv.getBytes(StandardCharsets.UTF_8);
+      // CSV 파일 형식
+      // ID,직원번호,이름,이메일,부서,직급,입사일,상태
+      // 144,EMP-2026-21410784000001,정채원,정채원45@gmail.com,백엔드 개발팀33,테크 리드,2025-09-10,ACTIVE
+
+      // 사원 전체 데이터를 호출
+      List<Employee> employees = employeeRepository.findAll();
+
+      // 직원의 입사일(hireDate)을 YYYY-MM-DD의 형태로 변환
+      // YYYY는 목요일을 기준으로 연도가 작년, 내년이 될 수 있음, yyyy는 정상적으로 연도 출력
+      // MM은 월 수, mm은 분(시간)
+      // DD는 연도 기준 일 수(1~365,366), dd는 월 기준 일 수
+      DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+      // StringBuilder를 사용하여 백업 데이터를 생성
+      StringBuilder sb = new StringBuilder();
+
+      // 헤더 생성(어떤 속성들 순서대로 넣을지)
+      // id, employeeNumber, name, email, department, position, hireData, status 순서대로
+      sb.append("ID,직원번호,이름,이메일,부서,직급,입사일,상태\n");
+
+      for (Employee employee : employees) {
+        sb.append(employee.getId()).append(",")
+            .append(employee.getEmployeeNumber()).append(",")
+            .append(employee.getName()).append(",")
+            .append(employee.getEmail()).append(",")
+            .append(employee.getDepartment().getName()).append(",")
+            .append(employee.getPosition()).append(",")
+            .append(employee.getHireDate().toString()).append(",")
+            .append(employee.getEmployeeStatus().toString()).append("\n");
+      }
+
+      // CSV 파일로 사원 백업 데이터를 CSV 파일로 변환
+      byte[] csvData = sb.toString().getBytes(StandardCharsets.UTF_8);
 
       file = fileService.saveInternalData("backup_data.csv", "text/csv", csvData);
 
@@ -105,7 +139,7 @@ public class BasicBackupService implements BackupService {
   public BackupResponse findLatest(BackupStatus status) {
     Backup backup = backupRepository.findTopByStatusOrderByEndedAtDesc(status)
         .orElseThrow(
-            () -> new IllegalArgumentException(status.getDescription() + " 상태의 백업이 없습니다.")
+            () -> new BusinessException(ErrorCode.BACKUP_NOT_FOUND)
         );
 
     return BackupResponse.from(backup);

--- a/src/main/java/com/sb11/hr_bank/global/exception/ErrorCode.java
+++ b/src/main/java/com/sb11/hr_bank/global/exception/ErrorCode.java
@@ -13,8 +13,6 @@ public enum ErrorCode {
 
   //예외 던질때 예시 -> throw new BusinessException(ErrorCode.EXAMPLE_EMPLOYEE_ERROR);
 
-
-
   // global
   GLOBAL_DUMMY_ERROR(500, "G001", "예시 메시지"),
 
@@ -38,18 +36,16 @@ public enum ErrorCode {
   FILE_STORAGE_ERROR(500, "F003", "파일 저장 중 오류가 발생했습니다."),
 
   // backup
-  //EXAMPLE_FILE_ERROR(500, "B001", "예시 메시지"),
+  BACKUP_NOT_FOUND(404, "B001", "백업을 찾을 수 없습니다."),
+  BACKUP_NOT_IN_PROGRESS(409, "B002", "백업이 진행 중이어야만 처리할 수 있습니다."),
+  BACKUP_REQUIRED_FILE(500, "B003", "백업 파일이 생성되지 않았습니다."),
 
 
-
-
-  DUMMY_ERROR(500,"G002", "DUMMY");
+  DUMMY_ERROR(500, "G002", "DUMMY");
 
   //
 
 
-
-  
   private final int status;
   private final String code;
   private final String detail;


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- 공통 영역 ErrorCode에 상태 에러 메시지를 추가하였습니다.
- ErrorCode에 추가한 상태 메시지를 Backup의 엔티티, 서비스(트랜잭션, 베이직, 레포지토리)에 활용하였습니다.
- csv 파일 생성 시 데이터의 일부 특수문자 따옴표, 쉼표, 줄바꿈, 따옴표(따옴표 안에 들어간 줄바꿈 쉼표 자체가 데이터로 인식되기 때문에)가 csv 틀을 깨지게 할 수 있기 때문에 해당 특수문자들을 공백처리 하였습니다.

## 🔗 관련 이슈
- Resolves: #이슈번호

## 🤔 리뷰어에게 부탁할 사항
- **공통 영역 파일(ErrorCode)**을 수정하였으므로, 머지 직후 git pull origin develope 명령어를 통해 꼭 로컬에 받아주세요 !

- 기존 4월 17일에 있던 해결된 깃 이슈(#36)를 자동으로 닫겠습니다.

Closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 백업 파일이 실제 직원 데이터와 yyyy-MM-dd 형식 입사일을 포함한 CSV로 생성됩니다.
  * 완료/실패 처리 시 파일 존재 및 상태 검증이 개선되어 예외 처리 흐름이 일관되게 동작합니다.

* **새로운 기능**
  * 상황별 전용 오류 코드 추가: BACKUP_NOT_FOUND, BACKUP_NOT_IN_PROGRESS, BACKUP_REQUIRED_FILE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->