### PR TITLE
Backup 백업 데이터를 커서 페이지네이션 기법을 적용시켜 조회(JPQL)

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/backup/dto/BackupResponse.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/dto/BackupResponse.java
@@ -20,7 +20,6 @@ public record BackupResponse(
         backup.getStartedAt(),
         backup.getEndedAt(),
         backup.getStatus(),
-//        backup.getFile() != null ? FileResponse.from(backup.getFile()) // 정적 팩토리 메서드로 작성할 시 교체 예정
         backup.getFile() != null ? backup.getFile().getId() : null
     );
   }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/dto/BackupResponse.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/dto/BackupResponse.java
@@ -2,7 +2,6 @@ package com.sb11.hr_bank.domain.backup.dto;
 
 import com.sb11.hr_bank.domain.backup.entity.Backup;
 import com.sb11.hr_bank.domain.backup.entity.BackupStatus;
-import com.sb11.hr_bank.domain.file.dto.FileResponse;
 import java.time.Instant;
 
 public record BackupResponse(
@@ -11,7 +10,7 @@ public record BackupResponse(
     Instant startedAt,
     Instant endedAt,
     BackupStatus status,
-    FileResponse file
+    Long fileId
 ) {
 
   public static BackupResponse from(Backup backup) {
@@ -22,10 +21,7 @@ public record BackupResponse(
         backup.getEndedAt(),
         backup.getStatus(),
 //        backup.getFile() != null ? FileResponse.from(backup.getFile()) // 정적 팩토리 메서드로 작성할 시 교체 예정
-        backup.getFile() != null ?
-            new FileResponse(backup.getFile().getId(),
-                backup.getFile().getName(), backup.getFile().getContentType(),
-                backup.getFile().getSize()) : null
+        backup.getFile() != null ? backup.getFile().getId() : null
     );
   }
 }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/dto/BackupSearchCondition.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/dto/BackupSearchCondition.java
@@ -8,8 +8,12 @@ public record BackupSearchCondition(
     Instant startFrom,
     Instant startTo,
     BackupStatus status,
-    Long cursor,
-    String sortBy
+
+    Long idAfter,
+    String cursor,
+    Integer size,
+    String sortField,
+    String sortDirection
 ) {
 
 }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/dto/BackupSearchCondition.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/dto/BackupSearchCondition.java
@@ -9,11 +9,9 @@ public record BackupSearchCondition(
     Instant startTo,
     BackupStatus status,
 
-    Long idAfter,
-    String cursor,
-    Integer size,
-    String sortField,
-    String sortDirection
+    Instant cursorStartedAt,
+    Long cursorId,
+    Integer size
 ) {
 
 }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/dto/BackupSearchCondition.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/dto/BackupSearchCondition.java
@@ -10,8 +10,13 @@ public record BackupSearchCondition(
     BackupStatus status,
 
     Instant cursorStartedAt,
+    Instant cursorEndedAt,
+    BackupStatus cursorStatus,
     Long cursorId,
-    Integer size
+    Integer size,
+    String sortField,
+    String sortDirection
+
 ) {
 
 }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/repository/BackupRepository.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/repository/BackupRepository.java
@@ -28,8 +28,10 @@ public interface BackupRepository extends JpaRepository<Backup, Long> {
                 or b.startedAt < :cursorStartedAt
                 or (b.startedAt = :cursorStartedAt and b.id < :cursorId)
             )
+            order by b.startedAt desc, b.id desc
       """)
-  Slice<Backup> search(@Param("worker") String worker, @Param("status") BackupStatus status,
+  Slice<Backup> search(@Param("worker") String worker,
+      @Param("status") BackupStatus status,
       @Param("startFrom") Instant startFrom, @Param("startTo") Instant startTo,
       @Param("cursorStartedAt") Instant cursorStartedAt, @Param("cursorId") Long cursorId,
       Pageable pageable);

--- a/src/main/java/com/sb11/hr_bank/domain/backup/repository/BackupRepository.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/repository/BackupRepository.java
@@ -3,11 +3,32 @@ package com.sb11.hr_bank.domain.backup.repository;
 
 import com.sb11.hr_bank.domain.backup.entity.Backup;
 import com.sb11.hr_bank.domain.backup.entity.BackupStatus;
+import java.time.Instant;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BackupRepository extends JpaRepository<Backup, Long> {
 
   // EndedAt 내림차순 정렬 가장 위 status를 확인
   Optional<Backup> findTopByStatusOrderByEndedAtDesc(BackupStatus status);
+
+  @Query("""
+      Select b from Backup b
+            where
+                  (:worker is null or b.worker like %:worker%)
+                        and(:status is null or b.status = :status)
+                              and(:startFrom is null or b.startedAt >= :startFrom)
+                                    and(:startTo is null or b.startedAt <= :startTo)
+                                          and(:idAfter is null or b.id < :idAfter) /* 2번째 페이지부터는 얘가 조회 이후의 첫번째 조회하도록 도와주는 필터 */
+                                                order by
+                                                      b.startedAt desc,
+                                                            b.id desc
+      """)
+  Slice<Backup> search(@Param("worker") String worker, @Param("status") BackupStatus status,
+      @Param("startFrom") Instant startFrom, @Param("startTo") Instant startTo,
+      @Param("idAfter") Long idAfter, Pageable pageable);
 }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/repository/BackupRepository.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/repository/BackupRepository.java
@@ -19,16 +19,18 @@ public interface BackupRepository extends JpaRepository<Backup, Long> {
   @Query("""
       Select b from Backup b
             where
-                  (:worker is null or b.worker like %:worker%)
-                        and(:status is null or b.status = :status)
-                              and(:startFrom is null or b.startedAt >= :startFrom)
-                                    and(:startTo is null or b.startedAt <= :startTo)
-                                          and(:idAfter is null or b.id < :idAfter) /* 2번째 페이지부터는 얘가 조회 이후의 첫번째 조회하도록 도와주는 필터 */
-                                                order by
-                                                      b.startedAt desc,
-                                                            b.id desc
+            (:worker is null or b.worker like %:worker%)
+            and(:status is null or b.status = :status)
+            and(:startFrom is null or b.startedAt >= :startFrom)
+            and(:startTo is null or b.startedAt <= :startTo)
+            and(
+                :cursorStartedAt is null
+                or b.startedAt < :cursorStartedAt
+                or (b.startedAt = :cursorStartedAt and b.id < :cursorId)
+            )
       """)
   Slice<Backup> search(@Param("worker") String worker, @Param("status") BackupStatus status,
       @Param("startFrom") Instant startFrom, @Param("startTo") Instant startTo,
-      @Param("idAfter") Long idAfter, Pageable pageable);
+      @Param("cursorStartedAt") Instant cursorStartedAt, @Param("cursorId") Long cursorId,
+      Pageable pageable);
 }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -16,15 +16,13 @@ import com.sb11.hr_bank.global.exception.ErrorCode;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -131,7 +129,7 @@ public class BasicBackupService implements BackupService {
   // 100~1까지 100개 있다고 가정했을 때
   // 앞에서부터 10개 단위로 조회(DB에는 order by desc), 임시 content 개수는 11개(100~90)
   // hasNext를 통해 개수를 10개로 줄임(100~91)
-  // last는 10개 중 마지막 번호인 91이 나옴 / nextIdAfter가 실제 91, nextCursor는 91을 base64시킨 문자열
+  // last는 10개 중 마지막 번호인 91이 나옴
   // 추후 91보다 작은 id를 order by desc로 조회 -> 90번부터 조회
   // 임시 content 개수는 11개 ... 반복
   @Override
@@ -141,11 +139,17 @@ public class BasicBackupService implements BackupService {
     // 페이지 size의 기본값(default)은 10
     int size = (condition.size() == null) ? 10 : condition.size();
 
-    // 정렬 방향과 정렬 기준을 설정(메서드 분리)
-    Sort sort = buildSort(condition.sortField(), condition.sortDirection());
+    // size가 음수거나 0일 경우
+    if (size <= 0) {
+      size = 10;
+    }
+
+    // cursor(startedAt과 Id로 정렬)
+    Instant cursorStartedAt = condition.cursorStartedAt();
+    Long cursorId = condition.cursorId();
 
     // pageable의 개수는 10+1 11개
-    Pageable pageable = PageRequest.of(0, size + 1, sort);
+    Pageable pageable = PageRequest.of(0, size + 1);
 
     // DB 조회 pageable 개수만큼(11개) 조회
     Slice<Backup> slice = backupRepository.search(
@@ -153,7 +157,8 @@ public class BasicBackupService implements BackupService {
         condition.status(),
         condition.startFrom(),
         condition.startTo(),
-        condition.idAfter(),
+        cursorStartedAt,
+        cursorId,
         pageable
     );
 
@@ -171,15 +176,21 @@ public class BasicBackupService implements BackupService {
     // content가 비면 null(마지막 원소 도달), 그렇지 않으면 마지막 데이터를 가져옴
     Backup last = content.isEmpty() ? null : content.get(content.size() - 1);
 
-    // nextIdAfter은 마지막 데이터 / 마지막 데이터가 비어있지 않으면 그 데이터의 id를, 비어있으면 null
-    Long nextIdAfter = last != null ? last.getId() : null;
+    String nextCursor = null;
 
-    // nextCursor은 마지막 데이터 / 비어있지않으면 String으로 변환 후 Base64언어로 변환, 비어있으면 null
-    String nextCursor =
-        (last != null) ? Base64.getEncoder().encodeToString(String.valueOf(last.getId()).getBytes())
-            : null;
+    if (last != null) {
+      nextCursor = last.getStartedAt().toString() + "|" + last.getId();
+    }
 
-    return PageResponse.fromSlice(slice.map(BackupResponse::from), nextCursor, nextIdAfter);
+    // DTO 변환
+    List<BackupResponse> mapped = content.stream().map(BackupResponse::from).toList();
+
+    // Slice 형태로 응답 생성
+    Slice<BackupResponse> responseSlice = new SliceImpl<>(mapped, pageable, hasNext);
+
+    //
+    return PageResponse.fromSlice(responseSlice, nextCursor,
+        last != null ? last.getId() : null);
   }
 
   // 가장 최근의 백업을 조회(상태별 조회)
@@ -208,27 +219,5 @@ public class BasicBackupService implements BackupService {
     value = value.replace(",", " ");
 
     return value;
-  }
-
-  // sortField와 sortDirection 처리 메서드
-  private Sort buildSort(String sortField, String sortDirection) {
-
-    // 정렬 방향을 결정(기본값은 DESC)
-    // equalsIgnoreCase는 대소문자를 구분하지 않도록 처리하는 메서드("AsC", "asC" 등 동일하게)
-    Direction direction =
-        "ASC".equalsIgnoreCase(sortDirection) ? Direction.ASC : Direction.DESC;
-
-    // 정렬 기준을 설정(기본값은 startedAt)
-    // 정렬 기준은 startedAt(시작시간) endedAt(종료시간) status(작업상태)
-    // endedAt, status가 아닌 다른 값이 들어오면 startedAt로 설정
-    String field = switch (sortField == null ? "startedAt" : sortField) {
-      case "endedAt" -> "endedAt";
-      case "status" -> "status";
-      default -> "startedAt";
-    };
-
-    // 선택한 기준과 방향으로 정렬(Sort.by(정렬 방향, 정렬 속성)
-    // 만약 정렬값(시작시간, 종료시간, 상태)이 완전히 같은게 있다면 id가 큰 순서로 정렬(id는 같을 수 없기 때문)
-    return Sort.by(direction, field).and(Sort.by(Direction.DESC, "id"));
   }
 }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -144,21 +145,25 @@ public class BasicBackupService implements BackupService {
       size = 10;
     }
 
-    // cursor(startedAt과 Id로 정렬)
-    Instant cursorStartedAt = condition.cursorStartedAt();
-    Long cursorId = condition.cursorId();
+    String sortField = condition.sortField() == null ? "startedAt" : condition.sortField();
 
-    // pageable의 개수는 10+1 11개
-    Pageable pageable = PageRequest.of(0, size + 1);
+    // 정렬 방향과 정렬 기준을 설정(메서드 분리)
+//    Sort sort = buildSort(sortField, condition.sortDirection());
 
-    // DB 조회 pageable 개수만큼(11개) 조회
+    // pageable의 개수는 10+1 11개(QueryDSL 사용 시 동적으로 수정)
+    Pageable pageable = PageRequest.of(0, size + 1,
+//        sort);
+        Sort.by(Sort.Direction.DESC, "startedAt")
+            .and(Sort.by(Sort.Direction.DESC, "id")));
+
+    // DB 조회 pageable 개수만큼(11개) 조회(startedAt, endedAt, status 별로 분리)
     Slice<Backup> slice = backupRepository.search(
         condition.worker(),
         condition.status(),
         condition.startFrom(),
         condition.startTo(),
-        cursorStartedAt,
-        cursorId,
+        condition.cursorStartedAt(),
+        condition.cursorId(),
         pageable
     );
 
@@ -220,4 +225,26 @@ public class BasicBackupService implements BackupService {
 
     return value;
   }
+//
+//  // sortField와 sortDirection 처리 메서드
+//  private Sort buildSort(String sortField, String sortDirection) {
+//
+//    // 정렬 방향을 결정(기본값은 DESC)
+//    // equalsIgnoreCase는 대소문자를 구분하지 않도록 처리하는 메서드("AsC", "asC" 등 동일하게)
+//    Direction direction =
+//        "ASC".equalsIgnoreCase(sortDirection) ? Direction.ASC : Direction.DESC;
+//
+//    // 정렬 기준을 설정(기본값은 startedAt)
+//    // 정렬 기준은 startedAt(시작시간) endedAt(종료시간) status(작업상태)
+//    // endedAt, status가 아닌 다른 값이 들어오면 startedAt로 설정
+//    String field = switch (sortField == null ? "startedAt" : sortField) {
+//      case "endedAt" -> "endedAt";
+//      case "status" -> "status";
+//      default -> "startedAt";
+//    };
+//
+//    // 선택한 기준과 방향으로 정렬(Sort.by(정렬 방향, 정렬 속성)
+//    // 만약 정렬값(시작시간, 종료시간, 상태)이 완전히 같은게 있다면 id가 큰 순서로 정렬(id는 같을 수 없기 때문)
+//    return Sort.by(direction, field).and(Sort.by(direction, "id"));
+//  }
 }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -139,8 +140,11 @@ public class BasicBackupService implements BackupService {
     // 페이지 size의 기본값(default)은 10
     int size = (condition.size() == null) ? 10 : condition.size();
 
+    // 정렬 방향과 정렬 기준을 설정(메서드 분리)
+    Sort sort = buildSort(condition.sortField(), condition.sortDirection());
+
     // pageable의 개수는 10+1 11개
-    Pageable pageable = PageRequest.of(0, size + 1);
+    Pageable pageable = PageRequest.of(0, size + 1, sort);
 
     // DB 조회 pageable 개수만큼(11개) 조회
     Slice<Backup> slice = backupRepository.search(
@@ -203,5 +207,27 @@ public class BasicBackupService implements BackupService {
     value = value.replace(",", " ");
 
     return value;
+  }
+
+  // sortField와 sortDirection 처리 메서드
+  private Sort buildSort(String sortField, String sortDirection) {
+
+    // 정렬 방향을 결정(기본값은 DESC)
+    // equalsIgnoreCase는 대소문자를 구분하지 않도록 처리하는 메서드("AsC", "asC" 등 동일하게)
+    Sort.Direction direction =
+        "ASC".equalsIgnoreCase(sortDirection) ? Sort.Direction.ASC : Sort.Direction.DESC;
+
+    // 정렬 기준을 설정(기본값은 startedAt)
+    // 정렬 기준은 startedAt(시작시간) endedAt(종료시간) status(작업상태)
+    // endedAt, status가 아닌 다른 값이 들어오면 startedAt로 설정
+    String field = switch (sortField == null ? "startedAt" : sortField) {
+      case "endedAt" -> "endedAt";
+      case "status" -> "status";
+      default -> "startedAt";
+    };
+
+    // 선택한 기준과 방향으로 정렬(Sort.by(정렬 방향, 정렬 속성)
+    // 만약 정렬값(시작시간, 종료시간, 상태)이 완전히 같은게 있다면 id가 큰 순서로 정렬(id는 같을 수 없기 때문)
+    return Sort.by(direction, field).and(Sort.by(Sort.Direction.DESC, "id"));
   }
 }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -16,6 +16,7 @@ import com.sb11.hr_bank.global.exception.ErrorCode;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -125,17 +126,55 @@ public class BasicBackupService implements BackupService {
   }
 
   // 백업 목록 조회
+  // 100~1까지 100개 있다고 가정했을 때
+  // 앞에서부터 10개 단위로 조회(DB에는 order by desc), 임시 content 개수는 11개(100~90)
+  // hasNext를 통해 개수를 10개로 줄임(100~91)
+  // last는 10개 중 마지막 번호인 91이 나옴 / nextIdAfter가 실제 91, nextCursor는 91을 base64시킨 문자열
+  // 추후 91보다 작은 id를 order by desc로 조회 -> 90번부터 조회
+  // 임시 content 개수는 11개 ... 반복
   @Override
   @Transactional(readOnly = true)
   public PageResponse<BackupResponse> findAll(BackupSearchCondition condition) {
-    Pageable pageable = PageRequest.of(0, 10);
 
-    Slice<Backup> slice = backupRepository.search(condition, pageable);
+    // 페이지 size의 기본값(default)은 10
+    int size = (condition.size() == null) ? 10 : condition.size();
 
-    Long nextIdAfter = slice.hasNext() ?
-        slice.getContent().get(slice.getNumberOfElements() - 1).getId() : null;
+    // pageable의 개수는 10+1 11개
+    Pageable pageable = PageRequest.of(0, size + 1);
 
-    return PageResponse.fromSlice(slice.map(BackupResponse::from), null, nextIdAfter);
+    // DB 조회 pageable 개수만큼(11개) 조회
+    Slice<Backup> slice = backupRepository.search(
+        condition.worker(),
+        condition.status(),
+        condition.startFrom(),
+        condition.startTo(),
+        condition.idAfter(),
+        pageable
+    );
+
+    // pageable 수만큼, 10+1개 11개를 가져옴
+    List<Backup> content = slice.getContent();
+
+    // 조회 결과 개수 > size이면 true
+    boolean hasNext = slice.hasNext();
+
+    // 0~9번까지 10개
+    if (hasNext) {
+      content = content.subList(0, size);
+    }
+
+    // content가 비면 null(마지막 원소 도달), 그렇지 않으면 마지막 데이터를 가져옴
+    Backup last = content.isEmpty() ? null : content.get(content.size() - 1);
+
+    // nextIdAfter은 마지막 데이터 / 마지막 데이터가 비어있지 않으면 그 데이터의 id를, 비어있으면 null
+    Long nextIdAfter = last != null ? last.getId() : null;
+
+    // nextCursor은 마지막 데이터 / 비어있지않으면 String으로 변환 후 Base64언어로 변환, 비어있으면 null
+    String nextCursor =
+        (last != null) ? Base64.getEncoder().encodeToString(String.valueOf(last.getId()).getBytes())
+            : null;
+
+    return PageResponse.fromSlice(slice.map(BackupResponse::from), nextCursor, nextIdAfter);
   }
 
   // 가장 최근의 백업을 조회(상태별 조회)

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -120,7 +120,7 @@ public class BasicBackupService implements BackupService {
 
       // 백업 최종 실패 시 CSV파일이 남아있을 경우 삭제
       if (file != null) {
-        // TODO 추후 실패시 만들었던 파일 삭제로직 호출하기
+        fileService.cleanupDummyFile(file.getId());
       }
 
     }

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,7 +63,7 @@ public class BasicBackupService implements BackupService {
     // 백업 시작(IN_PROGRESS 상태, 트랜잭션)
     Long backupId = backupTxService.createInProgress(worker);
 
-    FileEntity file;
+    FileEntity csvFile = null;
 
     try {
       // 정상적으로 백업 성공
@@ -101,10 +102,10 @@ public class BasicBackupService implements BackupService {
       // CSV 파일로 사원 백업 데이터를 CSV 파일로 변환
       byte[] csvData = sb.toString().getBytes(StandardCharsets.UTF_8);
 
-      file = fileService.saveInternalData("backup_data.csv", "text/csv", csvData);
+      csvFile = fileService.saveInternalData("backup_data.csv", "text/csv", csvData);
 
       // 백업 완료(COMPLETED 상태)
-      backupTxService.complete(backupId, file);
+      backupTxService.complete(backupId, csvFile);
 
     } catch (Exception e) {
       // 백업 실패(FAILED) 상태
@@ -113,14 +114,14 @@ public class BasicBackupService implements BackupService {
       byte[] logData = log.getBytes(StandardCharsets.UTF_8);
 
       // log 파일로 에러 로그 생성
-      file = fileService.saveInternalData("backup_error.log", "text/plain", logData);
+      FileEntity logFile = fileService.saveInternalData("backup_error.log", "text/plain", logData);
 
       // 백업 실패(FAILED 상태)
-      backupTxService.fail(backupId, file);
+      backupTxService.fail(backupId, logFile);
 
       // 백업 최종 실패 시 CSV파일이 남아있을 경우 삭제
-      if (file != null) {
-        fileService.cleanupDummyFile(file.getId());
+      if (csvFile != null) {
+        fileService.cleanupDummyFile(csvFile.getId());
       }
 
     }
@@ -214,8 +215,8 @@ public class BasicBackupService implements BackupService {
 
     // 정렬 방향을 결정(기본값은 DESC)
     // equalsIgnoreCase는 대소문자를 구분하지 않도록 처리하는 메서드("AsC", "asC" 등 동일하게)
-    Sort.Direction direction =
-        "ASC".equalsIgnoreCase(sortDirection) ? Sort.Direction.ASC : Sort.Direction.DESC;
+    Direction direction =
+        "ASC".equalsIgnoreCase(sortDirection) ? Direction.ASC : Direction.DESC;
 
     // 정렬 기준을 설정(기본값은 startedAt)
     // 정렬 기준은 startedAt(시작시간) endedAt(종료시간) status(작업상태)
@@ -228,6 +229,6 @@ public class BasicBackupService implements BackupService {
 
     // 선택한 기준과 방향으로 정렬(Sort.by(정렬 방향, 정렬 속성)
     // 만약 정렬값(시작시간, 종료시간, 상태)이 완전히 같은게 있다면 id가 큰 순서로 정렬(id는 같을 수 없기 때문)
-    return Sort.by(direction, field).and(Sort.by(Sort.Direction.DESC, "id"));
+    return Sort.by(direction, field).and(Sort.by(Direction.DESC, "id"));
   }
 }


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- 요구사항을 다시 확인하고 Backup dto에서 File의 ID만 받도록 수정하였습니다.
- Backup 서비스의 백업 데이터를 커서 페이지네이션 기법으로 조회하도록 적용하였습니다.
- Backup 레포지토리에 커서 페이지네이션 기법을 적용하기 위한 JPQL 메서드를 추가하였습니다.
- 백업이 실패했는데도 CSV 파일이 생성됐다면 해당 파일을 지우는 FileService의 cleanupDummyFile 메서드를 호출하였습니다.

## 🔗 관련 이슈
- Resolves: #이슈번호

## 🤔 리뷰어에게 부탁할 사항
- Backup 레포지토리의 경우 1차적으로 JPQL문을 작성하여 커서 페이지네이션 기법으로 조회하도록 적용하였습니다.
- PR 머지 이후 QueryDSL 방법을 사용하여 커서 페이지네이션 기법으로 조회하도록 적용할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 백업 검색에 커서 기반 페이지네이션과 페이지 크기(size) 설정이 도입되었습니다.
  * 검색 필터가 작업자, 상태 및 시작일 범위 조건을 지원하도록 강화되었습니다.
  * 백업 검색 결과의 다음 커서 제공으로 연속 조회가 개선되었습니다.
  * 백업 응답에 파일 전체 메타데이터 대신 파일 ID만 포함됩니다.

* **버그 수정**
  * 백업 실패 시 생성된 CSV 파일을 자동으로 정리하고 별도의 오류 로그 파일을 생성합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->