### PR TITLE
fix: 직원 수정 API 응답 DTO 반환

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/employee/controller/EmployeeApi.java
+++ b/src/main/java/com/sb11/hr_bank/domain/employee/controller/EmployeeApi.java
@@ -51,7 +51,7 @@ public interface EmployeeApi {
     );
 
     @Operation(summary = "직원 수정")
-    ResponseEntity<Void> update(
+    ResponseEntity<EmployeeDto> update(
             Long id,
             EmployeeUpdateRequest dto,
             MultipartFile profile

--- a/src/main/java/com/sb11/hr_bank/domain/employee/controller/EmployeeController.java
+++ b/src/main/java/com/sb11/hr_bank/domain/employee/controller/EmployeeController.java
@@ -86,13 +86,13 @@ public class EmployeeController implements EmployeeApi {
     }
 
     @PatchMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Void> update(
+    public ResponseEntity<EmployeeDto> update(
             @PathVariable Long id,
             @Valid @RequestPart("employee") EmployeeUpdateRequest dto,
             @RequestPart(value = "profile", required = false) MultipartFile profile
     ) {
-        employeeService.update(id, dto, profile);
-        return ResponseEntity.ok().build();
+        EmployeeDto result = employeeService.update(id, dto, profile);
+        return ResponseEntity.ok(result);
     }
 
     @DeleteMapping(value = "/{id}")

--- a/src/main/java/com/sb11/hr_bank/domain/employee/service/EmployeeService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/employee/service/EmployeeService.java
@@ -260,7 +260,7 @@ public class EmployeeService {
         return result;
     }
 
-    public void update(Long id, EmployeeUpdateRequest dto, MultipartFile profile) {
+    public EmployeeDto update(Long id, EmployeeUpdateRequest dto, MultipartFile profile) {
         Employee employee = employeeRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.EMPLOYEE_NOT_FOUND));
 
@@ -291,6 +291,8 @@ public class EmployeeService {
             if(newProfile != null && oldProfile != null) {
                 fileService.deleteFile(oldProfile.getId());
             }
+
+            return employeeMapper.toDto(employee);
         } catch (RuntimeException e) {
             cleanupUploadedFile(newProfile);
             throw e;


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- Employee Update API가 swaggerui 와 다르게 body를 반환하지 않아 해당부분 수정하였습니다.

## 🔗 관련 이슈


## 🤔 리뷰어에게 부탁할 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **API 개선**
  * 직원 정보 업데이트 API가 이제 업데이트된 직원 데이터를 응답으로 반환합니다. 이전의 빈 응답 대신 최신 정보를 즉시 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->