### PR TITLE
Backup 예외처리 개선과 JPAQueryFactory 생성자 긴급 수정

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/backup/entity/BackupStatus.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/entity/BackupStatus.java
@@ -2,6 +2,8 @@ package com.sb11.hr_bank.domain.backup.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.sb11.hr_bank.global.exception.BusinessException;
+import com.sb11.hr_bank.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -18,7 +20,7 @@ public enum BackupStatus {
         return status;
       }
     }
-    throw new IllegalArgumentException("Invalid BackupStatus description: " + description);
+    throw new BusinessException(ErrorCode.BACKUP_INVALID_STATUS);
   }
 
   // 직렬화(영어 -> 한글 / 예시 : IN_PROGRESS 프론트에서는 "진행중")

--- a/src/main/java/com/sb11/hr_bank/domain/backup/repository/BackupRepositoryImpl.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/repository/BackupRepositoryImpl.java
@@ -10,19 +10,22 @@ import com.sb11.hr_bank.domain.backup.entity.Backup;
 import com.sb11.hr_bank.domain.backup.entity.BackupStatus;
 import com.sb11.hr_bank.domain.backup.entity.QBackup;
 import com.sb11.hr_bank.domain.backup.query.BackupSortDirection;
+import jakarta.persistence.EntityManager;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
-@RequiredArgsConstructor
 public class BackupRepositoryImpl implements BackupRepositoryCustom {
 
   private final JPAQueryFactory queryFactory;
   private final QBackup b = QBackup.backup;
+
+  public BackupRepositoryImpl(EntityManager entityManager) {
+    this.queryFactory = new JPAQueryFactory(entityManager);
+  }
 
   @Override
   public Slice<Backup> search(BackupSearchCondition condition, BackupCursor cursor) {

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -225,7 +225,7 @@ public class BasicBackupService implements BackupService {
       String json = objectMapper.writeValueAsString(cursor);
       return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
     } catch (Exception e) {
-      throw new RuntimeException("Cursor encode 실패");
+      throw new BusinessException(ErrorCode.BACKUP_CURSOR_ENCODE_FAILED);
     }
   }
 
@@ -240,7 +240,7 @@ public class BasicBackupService implements BackupService {
 
       return objectMapper.readValue(json, BackupCursor.class);
     } catch (Exception e) {
-      throw new RuntimeException("Cursor decode 실패");
+      throw new BusinessException(ErrorCode.BACKUP_CURSOR_DECODE_FAILED);
     }
   }
 }

--- a/src/main/java/com/sb11/hr_bank/global/exception/ErrorCode.java
+++ b/src/main/java/com/sb11/hr_bank/global/exception/ErrorCode.java
@@ -47,6 +47,9 @@ public enum ErrorCode {
   BACKUP_NOT_FOUND(404, "B001", "백업을 찾을 수 없습니다."),
   BACKUP_NOT_IN_PROGRESS(409, "B002", "백업이 진행 중이어야만 처리할 수 있습니다."),
   BACKUP_REQUIRED_FILE(500, "B003", "백업 파일이 생성되지 않았습니다."),
+  BACKUP_INVALID_STATUS(400, "B004", "유효하지 않은 백업 상태입니다."),
+  BACKUP_CURSOR_ENCODE_FAILED(500, "B005", "커서 인코딩에 실패했습니다."),
+  BACKUP_CURSOR_DECODE_FAILED(500, "B006", "커서 디코딩에 실패했습니다."),
 
 
   DUMMY_ERROR(500, "G002", "DUMMY");


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- **global 패키지**의 BusinessException과 ErrorCode를 활용하여 BackupService와 BackupStatus에서 발생하는 예외들을 개선하였습니다.
- lombok의 `@RequiredArgsConstructor`을 사용하지 않고 JPAQueryFactory의 생성자를 직접 생성하였습니다.
## 🔗 관련 이슈
- Resolves: #이슈번호

## 🤔 리뷰어에게 부탁할 사항
- **공통영역(ErrorCode, BusinessException)**을 수정하였습니다.
  머지 후 로컬에서 git pull origin develope 명령어를 통해 꼭 받아주세요 !!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 백업 상태 검증 오류 처리 개선 - 유효하지 않은 상태에 대한 명확한 에러 응답 제공
  * 커서 인코딩/디코딩 실패 시 정확한 에러 코드 반환으로 디버깅 효율 향상

* **Chores**
  * 백업 기능 관련 에러 코드 3개 추가로 도메인별 오류 관리 체계 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->