### PR TITLE
Backup 파일명 개선, 작업자(IP주소)를 결정하는 로직 개선

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/backup/controller/BackupController.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/controller/BackupController.java
@@ -81,7 +81,7 @@ public class BackupController {
     }
 
     // localhost에서 테스트 시 IPV6 루프백 주소를 IPV4 주소로 변환
-    if ("0:0:0:0:0:1".equals(ip) || "::1".equals(ip)) {
+    if ("0:0:0:0:0:0:0:1".equals(ip) || "::1".equals(ip)) {
       return "127.0.0.1";
     }
 

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -19,6 +19,8 @@ import com.sb11.hr_bank.global.exception.BusinessException;
 import com.sb11.hr_bank.global.exception.ErrorCode;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.List;
@@ -106,7 +108,12 @@ public class BasicBackupService implements BackupService {
       // CSV 파일로 사원 백업 데이터를 CSV 파일로 변환
       byte[] csvData = sb.toString().getBytes(StandardCharsets.UTF_8);
 
-      csvFile = fileService.saveInternalData("backup_data.csv", "text/csv", csvData);
+      // 파일 이름 설정 employee_backup_(backupId)_(서울 기준 현재 시간).csv
+      String timestamp = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+          .format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss_SSS"));
+      String fileName = "employee_backup_" + backupId + "_" + timestamp + ".csv";
+
+      csvFile = fileService.saveInternalData(fileName, "text/csv", csvData);
 
       // 백업 완료(COMPLETED 상태)
       Backup completed = backupTxService.complete(backupId, csvFile);


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- IPV6 루프백 주소를 잘못 입력하여 이를 수정하였습니다.(기존 : "0:0:0:0:0:1" → 수정 : "0:0:0:0:0:0:0:1")
- 백업 성공 시 다운로드 할 csv 파일명을 개선하였습니다.

## 🔗 관련 이슈
- Resolves: #이슈번호

## 🤔 리뷰어에게 부탁할 사항
- IPV6주소가 나올 경우 해시함수로 변환시켜 길이를 줄이는 방향으로 임시 수정하였고,
그 외의 값은 ip주소가 아닌것으로 판단하여 "unknown"을 반환하도록 수정하였습니다 !

worker 결정 로직입니다 !
ip주소가 비어있을 경우(스케쥴러) -> "system"을 반환
로컬 주소가 IPV6 형태로 들어올 경우("0:0:0:0:0:0:0:1"이거나 "::1") -> "127.0.0.1"을 반환
IPV4주소일 경우 -> ipv4주소를 반환
IPV6주소일 경우 -> 해시함수로 변환된 문자열을 반환
그 외의 값일경우 -> "unknown" 반환

- 백업 파일명 예시입니다. employee_backup_31_20260422_111040_342
- 31은 백업ID, 20260422는 날짜, 111040_342는 현재 시간을 밀리세컨드까지 표현하도록 수정하였습니다 !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* IPv6 루프백 주소 처리 개선

## 새로운 기능
* 백업 파일명에 타임스탬프 자동 추가로 백업 파일 구분 용이

<!-- end of auto-generated comment: release notes by coderabbit.ai -->