### PR TITLE
Swagger 응답 예시 개선 및 README 파일에서 Backup 파트 설명 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,10 +159,10 @@ DELETED
 백업 상태는 다음 값을 사용합니다.
 
 ```text
-IN_PROGRESS
-COMPLETED
-FAILED
-SKIPPED
+IN_PROGRESS : 백업 진행중
+COMPLETED   : 백업 완료
+FAILED      : 백업 실패
+SKIPPED     : 백업을 건너뜀
 ```
 
 백업 완료 시 CSV 파일 형태로 백업 데이터를 제공합니다.  

--- a/src/main/java/com/sb11/hr_bank/domain/backup/controller/BackupApi.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/controller/BackupApi.java
@@ -3,9 +3,12 @@ package com.sb11.hr_bank.domain.backup.controller;
 import com.sb11.hr_bank.domain.backup.dto.BackupResponse;
 import com.sb11.hr_bank.domain.backup.dto.BackupSearchCondition;
 import com.sb11.hr_bank.domain.backup.entity.BackupStatus;
+import com.sb11.hr_bank.global.dto.ErrorResponse;
 import com.sb11.hr_bank.global.dto.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,8 +32,13 @@ public interface BackupApi {
   @Operation(summary = "데이터 백업 목록 조회", description = "데이터 백업 목록을 조회합니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "조회 성공"),
-      @ApiResponse(responseCode = "400", description = "유효하지 않은 요청(커서, 정렬, 상태값)입니다."),
-      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+      @ApiResponse(responseCode = "400", description = "유효하지 않은 요청(커서, 정렬, 상태값)입니다.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)
+          )
+      ),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+      ),
   })
   @GetMapping
   ResponseEntity<PageResponse<BackupResponse>> findAll(
@@ -42,9 +50,12 @@ public interface BackupApi {
   @Operation(summary = "데이터 백업 생성", description = "데이터 백업을 생성합니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "백업 생성 성공 또는 건너뜀"),
-      @ApiResponse(responseCode = "400", description = "유효하지 않은 요청입니다."),
-      @ApiResponse(responseCode = "409", description = "이미 백업이 진행중입니다."),
-      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+      @ApiResponse(responseCode = "400", description = "유효하지 않은 요청입니다.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "409", description = "이미 백업이 진행중입니다.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
   @PostMapping
   ResponseEntity<BackupResponse> startBackup(
@@ -56,10 +67,14 @@ public interface BackupApi {
   @Operation(summary = "최근 백업 조회", description = "가장 최근 백업 정보를 조회합니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "조회 성공"),
-      @ApiResponse(responseCode = "400", description = "유효하지 않은 상태입니다."),
-      @ApiResponse(responseCode = "404", description = "백업을 찾을 수 없습니다."),
-      @ApiResponse(responseCode = "409", description = "현재 상태에서는 요청을 처리할 수 없습니다."),
-      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+      @ApiResponse(responseCode = "400", description = "유효하지 않은 상태입니다.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "백업을 찾을 수 없습니다.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "409", description = "현재 상태에서는 요청을 처리할 수 없습니다.",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+          content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
   @GetMapping("/latest")
   ResponseEntity<BackupResponse> findLatest(

--- a/src/main/java/com/sb11/hr_bank/domain/backup/dto/BackupResponse.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/dto/BackupResponse.java
@@ -2,14 +2,27 @@ package com.sb11.hr_bank.domain.backup.dto;
 
 import com.sb11.hr_bank.domain.backup.entity.Backup;
 import com.sb11.hr_bank.domain.backup.entity.BackupStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 
 public record BackupResponse(
+
+    @Schema(description = "백업 ID", example = "1")
     Long id,
+
+    @Schema(description = "작업자", example = "127.0.0.1")
     String worker,
+
+    @Schema(description = "백업 시작 시간")
     Instant startedAt,
+
+    @Schema(description = "백업 완료 시간")
     Instant endedAt,
+
+    @Schema(description = "백업 상태", example = "완료")
     BackupStatus status,
+
+    @Schema(description = "백업 파일 ID", example = "1")
     Long fileId
 ) {
 
@@ -24,5 +37,3 @@ public record BackupResponse(
     );
   }
 }
-// mapper 클래스로 분리할지 ?
-// 정적 팩토리 메서드로 작성할지 ?

--- a/src/main/java/com/sb11/hr_bank/global/dto/ErrorResponse.java
+++ b/src/main/java/com/sb11/hr_bank/global/dto/ErrorResponse.java
@@ -1,5 +1,6 @@
 package com.sb11.hr_bank.global.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,9 +9,15 @@ import lombok.Setter;
 public class ErrorResponse {
 
   private final Instant timestamp;
+
+  @Schema(example = "400")
   private final int status;
+
+  @Schema(example = "잘못된 요청입니다.")
   private final String message;
+
   @Setter
+  @Schema(example = "부서 코드는 필수입니다.")
   private String details;
 
 
@@ -22,7 +29,7 @@ public class ErrorResponse {
   }
 
   //상태 코드에 따라 메시지는 고정. 세부 메시지는 ErrorCode에서.
-  private String resolveMessage(int status){
+  private String resolveMessage(int status) {
 
     return switch (status) {
       case (400) -> "잘못된 요청입니다.";
@@ -31,8 +38,6 @@ public class ErrorResponse {
       case (500) -> "요청 처리중 오류가 발생했습니다.";
       default -> "요청 처리중 오류가 발생했습니다. ";
     };
-
-
 
 
   }

--- a/src/main/java/com/sb11/hr_bank/global/dto/PageResponse.java
+++ b/src/main/java/com/sb11/hr_bank/global/dto/PageResponse.java
@@ -1,7 +1,6 @@
 package com.sb11.hr_bank.global.dto;
 
-import com.sb11.hr_bank.domain.department.dto.DepartmentResponse;
-import com.sb11.hr_bank.domain.department.entity.Department;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
@@ -9,15 +8,25 @@ import org.springframework.data.domain.Slice;
 public record PageResponse<T>(
 
     List<T> content,
+
+    @Schema(example = "eyJpZCI6MjB9")
     String nextCursor,
+
+    @Schema(example = "20")
     Long nextIdAfter,
+
+    @Schema(example = "10")
     int size,
+
+    @Schema(example = "100")
     Long totalElements,
+
+    @Schema(example = "true")
     boolean hasNext
 ) {
 
 
-  public static <T> PageResponse<T> fromPage(Page<T> page){
+  public static <T> PageResponse<T> fromPage(Page<T> page) {
 
     return new PageResponse<>(
 
@@ -32,7 +41,8 @@ public record PageResponse<T>(
 
 
   }
-  public static <T> PageResponse<T> fromSlice(Slice<T> slice, String nextCursor, Long nextIdAfter){
+
+  public static <T> PageResponse<T> fromSlice(Slice<T> slice, String nextCursor, Long nextIdAfter) {
 
     return new PageResponse<>(
 


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- Swagger 문서에서 Backup 도메인, PageResponse를 활용한 목록 조회, 에러 발생 시 ErrorResponse의 응답 예시를 개선하였습니다.
- README 파일의 Backup 파트에서 백업 상태에 대한 설명을 추가하였습니다.

## 🔗 관련 이슈
- Resolves: #이슈번호

## 🤔 리뷰어에게 부탁할 사항
- **공통영역(README.md, PageResponse, ErrorResponse)** 파일을 수정하였기 때문에
  머지 후 git pull origin develope 명령어로 꼭 로컬로 받아주세요 !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Enhanced API documentation with detailed error response specifications and field descriptions
* Improved backup status documentation with clearer value definitions
* Updated API schema examples and annotations for better API reference clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->