### PR TITLE
Fix: 부서 관리 비즈니스 에러 상태 코드 수정

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/department/controller/DepartmentApi.java
+++ b/src/main/java/com/sb11/hr_bank/domain/department/controller/DepartmentApi.java
@@ -19,8 +19,7 @@ public interface DepartmentApi {
   @Operation(summary = "부서 등록", description = "새로운 부서를 등록합니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "201", description = "부서 등록 성공"),
-      @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
-      @ApiResponse(responseCode = "409", description = "이미 존재하는 부서명입니다.")
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터 또는 이미 존재하는 부서명")
   })
   @PostMapping
   ResponseEntity<DepartmentResponse> createDepartment(@Valid @RequestBody DepartmentCreateRequest request);
@@ -28,9 +27,8 @@ public interface DepartmentApi {
   @Operation(summary = "부서 수정", description = "기존 부서의 정보를 수정합니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "부서 수정 성공"),
-      @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
-      @ApiResponse(responseCode = "404", description = "부서를 찾을 수 없음"),
-      @ApiResponse(responseCode = "409", description = "이미 존재하는 부서명입니다.")
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터 또는 이미 존재하는 부서명"),
+      @ApiResponse(responseCode = "404", description = "부서를 찾을 수 없음")
   })
   @PatchMapping("/{id}")
   ResponseEntity<DepartmentResponse> updateDepartment(@PathVariable Long id, @Valid @RequestBody DepartmentUpdateRequest request);
@@ -38,8 +36,8 @@ public interface DepartmentApi {
   @Operation(summary = "부서 삭제", description = "특정 부서를 삭제합니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "204", description = "부서 삭제 성공 (내용 없음)"),
-      @ApiResponse(responseCode = "404", description = "부서를 찾을 수 없음"),
-      @ApiResponse(responseCode = "409", description = "해당 부서에 소속된 직원이 있어 삭제할 수 없습니다.")
+      @ApiResponse(responseCode = "400", description = "해당 부서에 소속된 직원이 있어 삭제할 수 없습니다."),
+      @ApiResponse(responseCode = "404", description = "부서를 찾을 수 없음")
   })
   @DeleteMapping("/{id}")
   ResponseEntity<Void> deleteDepartment(@PathVariable Long id);

--- a/src/main/java/com/sb11/hr_bank/global/exception/ErrorCode.java
+++ b/src/main/java/com/sb11/hr_bank/global/exception/ErrorCode.java
@@ -31,8 +31,8 @@ public enum ErrorCode {
   // department
   //EXAMPLE_DEPARTMENT_ERROR(500, "D001", "예시 메시지"),
   DEPARTMENT_NOT_FOUND(404, "D001", "해당 부서를 찾을 수 없습니다."),
-  DEPARTMENT_DUPLICATE_NAME(409, "D002", "이미 존재하는 부서명입니다."),
-  DEPARTMENT_HAS_EMPLOYEES(409, "D003", "해당 부서에 소속된 직원이 있어 삭제할 수 없습니다."),
+  DEPARTMENT_DUPLICATE_NAME(400, "D002", "이미 존재하는 부서명입니다."),
+  DEPARTMENT_HAS_EMPLOYEES(400, "D003", "해당 부서에 소속된 직원이 있어 삭제할 수 없습니다."),
 
   // changeLogs
   //EXAMPLE_DEPARTMENT_ERROR(500, "C001", "예시 메시지"),


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- 기존에 409 Conflict로 던지던 예외(부서명 중복, 소속 직원 존재 시 삭제 불가)를 프론트엔드의 에러 메시지 팝업 처리 규격에 맞추어 400 Bad Request로 하향 조정
- ErrorCode 내 D002, D003의 HTTP 상태 코드를 400으로 변경
- DepartmentApi(Swagger) 문서 내 응답 코드 명세를 400으로 통일하여 정합성 확보

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 부서 생성 및 업데이트 시 중복된 부서명에 대한 오류 응답 상태 코드 수정
  * 직원이 있는 부서 삭제 시도 시 오류 응답 상태 코드 수정
  * API 오류 응답의 HTTP 상태 코드를 더 정확한 값으로 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->