### PR TITLE
ChangeLog null 조회 대응 및 N+1 개선

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/service/ChangeLogService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/service/ChangeLogService.java
@@ -17,6 +17,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -92,9 +95,16 @@ public class ChangeLogService {
     }
 
     // NPE 방어
+    Map<Long, Employee> employeeMap = employeeRepository.findAllById(
+            logSlice.getContent().stream()
+                    .map(ChangeLog::getEmployeeId)
+                    .filter(Objects::nonNull)
+                    .distinct()
+                    .toList()
+    ).stream().collect(Collectors.toMap(Employee::getId, Function.identity()));
+
     Slice<ChangeLogResponseDto.ListInfo> dtoSlice = logSlice.map(log -> {
-      Employee employee = employeeRepository.findById(log.getEmployeeId())
-              .orElse(null);
+      Employee employee = employeeMap.get(log.getEmployeeId());
       String empNum = (employee != null)
           ? employee.getEmployeeNumber()
           : "Unknown (Deleted)";
@@ -124,8 +134,10 @@ public class ChangeLogService {
         .orElseThrow(() -> new BusinessException(ErrorCode.CHANGELOG_NOT_FOUND));
 
     // 직원 정보 NPE 방어
-    Employee employee = employeeRepository.findById(log.getEmployeeId())
-            .orElse(null);
+    Long employeeId = log.getEmployeeId();
+    Employee employee = employeeId != null
+            ? employeeRepository.findById(employeeId).orElse(null)
+            : null;
     String empNum = (employee != null) ? employee.getEmployeeNumber() : "Unknown";
     String empName = (employee != null) ? employee.getName() : "탈퇴한 사용자";
 


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- ChangeLogService에서 null인 Id로 Employee를 조회하는 케이스에 대한 방어
- ChangeLog에서 Employee를 조회하는 과정에 생기는 N+1 개선

## 🔗 관련 이슈


## 🤔 리뷰어에게 부탁할 사항
- 이후 PR에서 conflict가 발생할 수 있습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  - 변경 로그 상세 조회 시 직원 정보 누락 상황 처리 안정성 개선

* **리팩토링**
  - 변경 로그 목록 조회 시 데이터 로딩 효율성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->