### PR TITLE
fix: HR Bank 홈페이지에 수정이력 목록이 뜨지 않는 버그 수정

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/controller/ChangeLogController.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/controller/ChangeLogController.java
@@ -13,7 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.time.Instant;
 
-@Tag(name = "Change Log API", description = "직원 정보 변경 이력 API")
+@Tag(name = "직원 정보 수정 이력 관리", description = "직원 정보 변경 이력 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/change-logs")

--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/repository/ChangeLogRepository.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/repository/ChangeLogRepository.java
@@ -132,7 +132,7 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
                           SELECT 1
                           FROM Employee e
                           WHERE e.id = c.employeeId
-                                  AND e.employeeNumber LIKE CONCAT('%', :empNum, '%')
+                                  AND e.employeeNumber LIKE CONCAT('%', CAST(:empNum AS string), '%')
                   )
           )
           AND (:memo IS NULL OR c.memo LIKE CONCAT('%', CAST(:memo AS string), '%'))

--- a/src/main/java/com/sb11/hr_bank/domain/changelogs/repository/ChangeLogRepository.java
+++ b/src/main/java/com/sb11/hr_bank/domain/changelogs/repository/ChangeLogRepository.java
@@ -26,16 +26,14 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
             (CAST(:atAfter AS timestamp) IS NULL OR c.createdAt < :atAfter)
             OR (c.createdAt = :atAfter AND c.id < :idAfter)
         )
-        AND (
-                :empNum IS NULL OR EXISTS (
-                        SELECT 1
-                        FROM Employee e
-                        WHERE e.id = c.employeeId
-                                AND e.employeeNumber = :empNum
-                )
-        )
-        AND (:memo IS NULL OR c.memo LIKE CONCAT('%', :memo, '%'))
-        AND (:searchIp IS NULL OR c.ipAddress = :searchIp)
+        AND (:empNum IS NULL OR :empNum = '' OR EXISTS (
+                SELECT 1
+                FROM Employee e
+                WHERE e.id = c.employeeId
+                        AND e.employeeNumber LIKE CONCAT('%', CAST(:empNum AS string), '%')
+        ))
+        AND (:memo IS NULL OR c.memo LIKE CONCAT('%', CAST(:memo AS string), '%'))
+        AND (:ipAddress IS NULL OR c.ipAddress LIKE CONCAT('%', CAST(:ipAddress AS string), '%'))
         AND (:type IS NULL OR c.type = :type)
         AND (CAST(:atFrom AS timestamp) IS NULL OR c.createdAt >= :atFrom)
         AND (CAST(:atTo AS timestamp) IS NULL OR c.createdAt <= :atTo)
@@ -46,7 +44,7 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
       @Param("idAfter") Long idAfter,
       @Param("empNum") String empNum,
       @Param("memo") String memo,
-      @Param("searchIp") String searchIp,
+      @Param("ipAddress") String ipAddress,
       @Param("type") ChangeLogType type,
       @Param("atFrom") Instant atFrom,
       @Param("atTo") Instant atTo,
@@ -55,32 +53,32 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
 
   // 시간 ASC
   @Query("""
-          SELECT c FROM ChangeLog c
-          WHERE (
-              (CAST(:atAfter AS timestamp) IS NULL OR c.createdAt > :atAfter)
-              OR (c.createdAt = :atAfter AND c.id > :idAfter)
-          )
-          AND (
-                  :empNum IS NULL OR EXISTS (
-                          SELECT 1
-                          FROM Employee e
-                          WHERE e.id = c.employeeId
-                                  AND e.employeeNumber = :empNum
-                  )
-          )
-          AND (:memo IS NULL OR c.memo LIKE CONCAT('%', :memo, '%'))
-          AND (:searchIp IS NULL OR c.ipAddress = :searchIp)
-          AND (:type IS NULL OR c.type = :type)
-          AND (CAST(:atFrom AS timestamp) IS NULL OR c.createdAt >= :atFrom)
-          AND (CAST(:atTo AS timestamp) IS NULL OR c.createdAt <= :atTo)
-          ORDER BY c.createdAt ASC, c.id ASC
-          """)
+        SELECT c FROM ChangeLog c
+        WHERE (
+            (CAST(:atAfter AS timestamp) IS NULL OR c.createdAt > :atAfter)
+            OR (c.createdAt = :atAfter AND c.id > :idAfter)
+        )
+        AND (
+                :empNum IS NULL OR :empNum = '' OR EXISTS (
+                        SELECT 1
+                        FROM Employee e
+                        WHERE e.id = c.employeeId
+                                AND e.employeeNumber LIKE CONCAT('%', CAST(:empNum AS string), '%')
+                )
+        )
+        AND (:memo IS NULL OR c.memo LIKE CONCAT('%', CAST(:memo AS string), '%'))
+        AND (:ipAddress IS NULL OR c.ipAddress LIKE CONCAT('%', CAST(:ipAddress AS string), '%'))
+        AND (:type IS NULL OR c.type = :type)
+        AND (CAST(:atFrom AS timestamp) IS NULL OR c.createdAt >= :atFrom)
+        AND (CAST(:atTo AS timestamp) IS NULL OR c.createdAt <= :atTo)
+        ORDER BY c.createdAt ASC, c.id ASC
+      """)
   Slice<ChangeLog> findByCursorAtAsc(
       @Param("atAfter") Instant atAfter,
       @Param("idAfter") Long idAfter,
       @Param("empNum") String empNum,
       @Param("memo") String memo,
-      @Param("searchIp") String searchIp,
+      @Param("ipAddress") String ipAddress,
       @Param("type") ChangeLogType type,
       @Param("atFrom") Instant atFrom,
       @Param("atTo") Instant atTo,
@@ -96,15 +94,15 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
             OR (c.ipAddress = :ipAfter AND c.id < :idAfter)
         )
         AND (
-                :empNum IS NULL OR EXISTS (
+                :empNum IS NULL OR :empNum = '' OR EXISTS (
                         SELECT 1
                         FROM Employee e
                         WHERE e.id = c.employeeId
-                                AND e.employeeNumber = :empNum
+                                AND e.employeeNumber LIKE CONCAT('%', CAST(:empNum AS string), '%')
                 )
         )
-        AND (:memo IS NULL OR c.memo LIKE CONCAT('%', :memo, '%'))
-        AND (:searchIp IS NULL OR c.ipAddress = :searchIp)
+        AND (:memo IS NULL OR c.memo LIKE CONCAT('%', CAST(:memo AS string), '%'))
+        AND (:ipAddress IS NULL OR c.ipAddress LIKE CONCAT('%', CAST(:ipAddress AS string), '%'))
         AND (:type IS NULL OR c.type = :type)
         AND (CAST(:atFrom AS timestamp) IS NULL OR c.createdAt >= :atFrom)
         AND (CAST(:atTo AS timestamp) IS NULL OR c.createdAt <= :atTo)
@@ -115,7 +113,7 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
       @Param("idAfter") Long idAfter,
       @Param("empNum") String empNum,
       @Param("memo") String memo,
-      @Param("searchIp") String searchIp,
+      @Param("ipAddress") String ipAddress,
       @Param("type") ChangeLogType type,
       @Param("atFrom") Instant atFrom,
       @Param("atTo") Instant atTo,
@@ -130,15 +128,15 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
               OR (c.ipAddress = :ipAfter AND c.id > :idAfter)
           )
           AND (
-                  :empNum IS NULL OR EXISTS (
+                  :empNum IS NULL OR :empNum = '' OR EXISTS (
                           SELECT 1
                           FROM Employee e
                           WHERE e.id = c.employeeId
-                                  AND e.employeeNumber = :empNum
+                                  AND e.employeeNumber LIKE CONCAT('%', :empNum, '%')
                   )
           )
-          AND (:memo IS NULL OR c.memo LIKE CONCAT('%', :memo, '%'))
-          AND (:searchIp IS NULL OR c.ipAddress = :searchIp)
+          AND (:memo IS NULL OR c.memo LIKE CONCAT('%', CAST(:memo AS string), '%'))
+          AND (:ipAddress IS NULL OR c.ipAddress LIKE CONCAT('%', CAST(:ipAddress AS string), '%'))
           AND (:type IS NULL OR c.type = :type)
           AND (CAST(:atFrom AS timestamp) IS NULL OR c.createdAt >= :atFrom)
           AND (CAST(:atTo AS timestamp) IS NULL OR c.createdAt <= :atTo)
@@ -149,7 +147,7 @@ public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
       @Param("idAfter") Long idAfter,
       @Param("empNum") String empNum,
       @Param("memo") String memo,
-      @Param("searchIp") String searchIp,
+      @Param("ipAddress") String ipAddress,
       @Param("type") ChangeLogType type,
       @Param("atFrom") Instant atFrom,
       @Param("atTo") Instant atTo,


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- 직원 수정 이력 목록과 상세 내역에 항목이 뜨지 않던 부분 버그 수정 완료했습니다

## 🔗 관련 이슈
- Resolves: #85 

## 🤔 리뷰어에게 부탁할 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 직원번호, 메모, IP 주소 필터의 검색 방식을 부분 문자열 검색으로 개선하여 더 유연하고 포괄적인 검색 결과를 제공합니다.

* **문서**
  * API 문서에 표시되는 변경 이력 관련 라벨을 한국어 명칭으로 업데이트하여 문서 가독성을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->