### PR TITLE
Backup 상태코드 개선, 진행중 상태 반환 차단

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/backup/controller/BackupApi.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/controller/BackupApi.java
@@ -71,8 +71,6 @@ public interface BackupApi {
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
       @ApiResponse(responseCode = "404", description = "백업을 찾을 수 없습니다.",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-      @ApiResponse(responseCode = "409", description = "현재 상태에서는 요청을 처리할 수 없습니다.",
-          content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
       @ApiResponse(responseCode = "500", description = "서버 내부 오류",
           content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })

--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -70,7 +70,7 @@ public class BasicBackupService implements BackupService {
 
     // 백업이 필요하지 않을 경우(이미 백업 진행 후에 변경 이력이 없을 경우)
     // 백업 건너뜀(SKIPPED 상태)
-    if (!needBackup) {
+    if (!needBackup || !(employeeRepository.existsByIdIsNotNull())) {
       Backup skipped = Backup.skip(worker);
       backupRepository.save(skipped);
       return BackupResponse.from(skipped);

--- a/src/main/java/com/sb11/hr_bank/domain/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/sb11/hr_bank/domain/employee/repository/EmployeeRepository.java
@@ -1,30 +1,36 @@
 package com.sb11.hr_bank.domain.employee.repository;
 
 import com.sb11.hr_bank.domain.employee.entity.Employee;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
-
 public interface EmployeeRepository
-        extends JpaRepository<Employee, Long>,
-        JpaSpecificationExecutor<Employee>,
-        EmployeeRepositoryCustom {
+    extends JpaRepository<Employee, Long>,
+    JpaSpecificationExecutor<Employee>,
+    EmployeeRepositoryCustom {
 
-    Optional<Employee> findByEmail(String email);
-    Long countByHireDateBetween(LocalDate start, LocalDate end);
-    Long countByHireDateLessThan(LocalDate date);
-    boolean existsByDepartmentId(Long departmentId);
-    List<Employee> findByDepartmentId(Long departmentId);
-    List<Employee> findByDepartmentIdIn(List<Long> departmentIds);
+  Optional<Employee> findByEmail(String email);
 
-    @Query("SELECT MAX(e.employeeNumber) FROM Employee e WHERE e.employeeNumber LIKE CONCAT('EMP-', :year, '-%')")
-    Optional<String> findMaxEmployeeNumberByYear(@Param("year") int year);
+  Long countByHireDateBetween(LocalDate start, LocalDate end);
 
-    @Query("SELECT e FROM Employee e JOIN FETCH e.department")
-    List<Employee> findAllWithDepartment();
+  Long countByHireDateLessThan(LocalDate date);
+
+  boolean existsByDepartmentId(Long departmentId);
+
+  List<Employee> findByDepartmentId(Long departmentId);
+
+  List<Employee> findByDepartmentIdIn(List<Long> departmentIds);
+
+  @Query("SELECT MAX(e.employeeNumber) FROM Employee e WHERE e.employeeNumber LIKE CONCAT('EMP-', :year, '-%')")
+  Optional<String> findMaxEmployeeNumberByYear(@Param("year") int year);
+
+  @Query("SELECT e FROM Employee e JOIN FETCH e.department")
+  List<Employee> findAllWithDepartment();
+
+  boolean existsByIdIsNotNull();
 }

--- a/src/main/java/com/sb11/hr_bank/global/exception/ErrorCode.java
+++ b/src/main/java/com/sb11/hr_bank/global/exception/ErrorCode.java
@@ -53,7 +53,7 @@ public enum ErrorCode {
   BACKUP_CURSOR_ENCODE_FAILED(500, "B005", "커서 인코딩에 실패했습니다."),
   BACKUP_CURSOR_DECODE_FAILED(400, "B006", "커서 디코딩에 실패했습니다."),
   BACKUP_INVALID_SORT_FIELD(400, "B007", "유효하지 않은 정렬 기준입니다."),
-  BACKUP_ALREADY_IN_PROGRESS(400, "B008", "이미 백업이 진행중입니다."),
+  BACKUP_ALREADY_IN_PROGRESS(409, "B008", "이미 백업이 진행중입니다."),
 
   DUMMY_ERROR(500, "G002", "DUMMY");
 


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- 백업 Request에 대한 상태코드를 개선하였습니다.
- 초기 백업 데이터 생성 시 진행중인 상태로 반환되는 문제를 수정하였습니다.(무조건 성공, 실패, 건너뛰도록 개선하였습니다.)

## 🔗 관련 이슈
- Resolves: #이슈번호

## 🤔 리뷰어에게 부탁할 사항
- 백업을 수행하는 POST 요청의 경우 성공 시 201을 할지 200을 할지 고민하였는데, REST 기준으로 볼 때 200이 자연스러운거 같아서 그대로 200으로 유지하였습니다.(독립된 새로운 리소스, 아예 새로운 리소스를 만드는게 아니라 기존에 있는, 직원 데이터를 바탕으로 파일을 만들었기 때문입니다)
- 직원 테이블에 데이터가 없을 시 백업을 요청할 경우 진행중인 상태로 반환되는 문제를 수정하였습니다 !
- 코드를 개선하면서 EmployeeRepository를 수정하였는데 담당하시는 태훈님과 상의 후 제쪽에서 코드를 추가하여 진행하기로 하였습니다 !