### PR TITLE
refactor: 파일 상태 기반 예외 처리 도입 및 내부 트랜잭션 분리

### DIFF
--- a/src/main/java/com/sb11/hr_bank/HrBankApplication.java
+++ b/src/main/java/com/sb11/hr_bank/HrBankApplication.java
@@ -3,7 +3,9 @@ package com.sb11.hr_bank;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 @EnableJpaAuditing
 public class HrBankApplication {

--- a/src/main/java/com/sb11/hr_bank/domain/file/entity/FileEntity.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/entity/FileEntity.java
@@ -33,9 +33,22 @@ public class FileEntity extends BaseEntity {
   @Column(nullable = false)
   private Long size;
 
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private FileStatus status;
+
   public FileEntity(String name, String contentType, Long size) {
     this.name = name;
     this.contentType = contentType;
     this.size = size;
+    this.status = FileStatus.PENDING;
+  }
+
+  public void activate() {
+    this.status = FileStatus.ACTIVE;
+  }
+
+  public void fail() {
+    this.status = FileStatus.FAILED;
   }
 }

--- a/src/main/java/com/sb11/hr_bank/domain/file/entity/FileStatus.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/entity/FileStatus.java
@@ -1,0 +1,7 @@
+package com.sb11.hr_bank.domain.file.entity;
+
+public enum FileStatus {
+  PENDING,  //파일 업로드 시작
+  ACTIVE,   //파일 저장 완료 및 정상 사용 가능 상태
+  FAILED    //파일 저장 중 오류 발생
+}

--- a/src/main/java/com/sb11/hr_bank/domain/file/repository/FileRepository.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/repository/FileRepository.java
@@ -1,10 +1,14 @@
 package com.sb11.hr_bank.domain.file.repository;
 
 import com.sb11.hr_bank.domain.file.entity.FileEntity;
+import com.sb11.hr_bank.domain.file.entity.FileStatus;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FileRepository extends JpaRepository<FileEntity, Long> {
 
+  //스케줄러가 FAILED 상태인 고아 파일을 찾기 위해 사용되는 메서드
+  List<FileEntity> findAllByStatus(FileStatus status);
 }

--- a/src/main/java/com/sb11/hr_bank/domain/file/scheduler/FileCleanupScheduler.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/scheduler/FileCleanupScheduler.java
@@ -1,0 +1,38 @@
+package com.sb11.hr_bank.domain.file.scheduler;
+
+import com.sb11.hr_bank.domain.file.entity.FileEntity;
+import com.sb11.hr_bank.domain.file.entity.FileStatus;
+import com.sb11.hr_bank.domain.file.repository.FileRepository;
+import com.sb11.hr_bank.domain.file.service.FileService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FileCleanupScheduler {
+
+  private final FileRepository fileRepository;
+  private final FileService fileService;
+
+  @Scheduled(cron = "0 0 3 * * *")
+  public void cleanupFailedFiles() {
+    log.info("고아 파일 정리 스케줄러 시작");
+
+    //FAILED 상태인 파일 조회
+    List<FileEntity> failedFiles = fileRepository.findAllByStatus(FileStatus.FAILED);
+
+    for (FileEntity file : failedFiles) {
+      try {
+        fileService.deleteFailedFile(file);
+      } catch (Exception e) {
+        log.error("실패 파일 삭제 중 오류 발생: ID = {}", file.getId(), e);
+      }
+    }
+
+    log.info("고아 파일 정리 스케줄러 종료. 총 {}건 처리", failedFiles.size());
+  }
+}

--- a/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
@@ -138,4 +138,19 @@ public class FileService {
       log.error("로컬 파일 삭제 실패: {}", destPath, e);
     }
   }
+
+  @Transactional
+  public void deleteFailedFile(FileEntity fileEntity) {
+    Path destPath = getAbsolutePath(fileEntity.getId());
+
+    //DB 메타데이터 강제 삭제
+    fileRepository.delete(fileEntity);
+
+    try {
+      Files.deleteIfExists(destPath);
+      log.info("로컬 더미 파일 삭제 완료: {}", destPath);
+    } catch (IOException e) {
+      log.error("로컬 더미 파일 삭제 실패: {}", destPath, e);
+    }
+  }
 }

--- a/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/file/service/FileService.java
@@ -1,6 +1,7 @@
 package com.sb11.hr_bank.domain.file.service;
 
 import com.sb11.hr_bank.domain.file.entity.FileEntity;
+import com.sb11.hr_bank.domain.file.entity.FileStatus;
 import com.sb11.hr_bank.domain.file.repository.FileRepository;
 import com.sb11.hr_bank.global.exception.BusinessException;
 import com.sb11.hr_bank.global.exception.ErrorCode;
@@ -11,9 +12,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j //로그 사용을 위한 어노테이션
@@ -29,37 +29,50 @@ public class FileService {
   }
 
   //파일 업로드 클래스 (로컬 디스크 저장 및 DB 기록)
-  @Transactional
+  @Transactional(noRollbackFor = BusinessException.class)
   public FileEntity uploadFile(MultipartFile file) {
     //빈 파일 검증
     if (file == null || file.isEmpty()) {
       throw new BusinessException(ErrorCode.FILE_EMPTY);
     }
 
+    //PENDING 상태로 DB 메타데이터 저장
     FileEntity savedEntity = saveMetadata(file.getOriginalFilename(), file.getContentType(), file.getSize());
 
     //ID를 파일명으로 로컬 디스크에 저장
     Path destPath = getAbsolutePath(savedEntity.getId());
 
     try {
+      //로컬 파일 저장 시도
       file.transferTo(destPath.toFile());
+
+      //파일 저장 성공 시 상태를 ACTIVE로 변경
+      savedEntity.activate();
+      return fileRepository.save(savedEntity);
+
     } catch (IOException | IllegalStateException e) {
+      log.error("파일 업로드 실패. 파일 ID: {}", savedEntity.getId(), e);
+      //실패 시 상태를 FAILED로 변경
+      savedEntity.fail();
+      fileRepository.save(savedEntity);
       throw new BusinessException(ErrorCode.FILE_STORAGE_ERROR);
     }
-
-    //저장된 파일의 ID 리턴
-    return savedEntity;
   }
 
-  //파일 메타데이터 단건 조회
+  //파일 메타데이터 단건 조회(ACTIVE 상태인 파일만 조회 가능)
   public FileEntity getFileMetadata(Long id) {
-    return fileRepository.findById(id)
-        .orElseThrow(() -> new BusinessException(
-            ErrorCode.FILE_NOT_FOUND));
+    FileEntity entity = fileRepository.findById(id).orElseThrow(
+        () -> new BusinessException(ErrorCode.FILE_NOT_FOUND));
+
+    if (entity.getStatus() != FileStatus.ACTIVE) {
+      throw new BusinessException(ErrorCode.FILE_NOT_FOUND);
+    }
+
+    return entity;
   }
 
   //서버 내부 파일 저장용 메서드
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW, noRollbackFor = BusinessException.class)
   public FileEntity saveInternalData(String originalFilename, String contentType, byte[] data) {
     //data 검증
     if (data == null || data.length == 0) {
@@ -69,12 +82,22 @@ public class FileService {
     FileEntity savedEntity = saveMetadata(originalFilename, contentType, (long) data.length);
     //ID를 파일명으로 로컬 디스크에 기록
     Path destPath = getAbsolutePath(savedEntity.getId());
+    
     try {
+      //파일 기록 시도
       Files.write(destPath, data);
+
+      //성공 시 ACTIVE
+      savedEntity.activate();
+      return fileRepository.save(savedEntity);
+
     } catch (IOException e) {
+      log.error("내부 파일 저장 실패. 파일 ID: {}", savedEntity.getId(), e);
+      //실패 시 FAILED
+      savedEntity.fail();
+      fileRepository.save(savedEntity);
       throw new BusinessException(ErrorCode.FILE_STORAGE_ERROR);
     }
-    return savedEntity;
   }
 
   //파일 저장 공용 메서드
@@ -101,45 +124,18 @@ public class FileService {
   public void deleteFile(Long id) {
     //DB 메타데이터 조회
     FileEntity fileEntity = getFileMetadata(id);
-
-    //로컬 디스크 파일 삭제
     Path destPath = getAbsolutePath(fileEntity.getId());
 
     //DB 메타데이터 삭제
     fileRepository.delete(fileEntity);
 
     //DB 트랙잭션이 커밋된 이후 로컬 파일 삭제
-    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-      @Override
-      public void afterCommit() {
-        try {
-          Files.deleteIfExists(destPath);
-          log.info("로컬 파일 삭제 성공: {}", destPath);
-        } catch (IOException e) {
-          //DB 커밋이 끝났으므로 롤백 불가, 에러 로그 남김
-          log.error("로컬 파일 삭제 실패: {}", destPath, e);
-        }
-      }
-    });
-  }
-
-  //더미 파일 정리 메서드(트랙잭션 커밋을 기다리지 않고 로컬 파일 삭제)
-  @Transactional
-  public void cleanupDummyFile(Long id) {
-    FileEntity fileEntity = getFileMetadata(id);
-    Path destPath = getAbsolutePath(fileEntity.getId());
-    
-    //커밋을 기다리지 않고 로컬 파일 삭제
     try {
-      //로컬 파일 삭제 시도
       Files.deleteIfExists(destPath);
-      log.info("에러 복구: 롤백 대비 더미 파일 삭제 완료: {}", destPath);
-
-      //로컬 파일 삭제 성공 시 DB 메타데이터 삭제
-      fileRepository.delete(fileEntity);
+      log.info("로컬 파일 삭제 성공: {}", destPath);
     } catch (IOException e) {
-      //에러 발생 시 DB 삭제 코드는 실행 되지 않음
-      log.error("에러 복구: 더미 파일 삭제 실패(수동 확인 필요): {}", destPath, e);
+      //DB 커밋이 끝났으므로 롤백 불가, 에러 로그 남김
+      log.error("로컬 파일 삭제 실패: {}", destPath, e);
     }
   }
 }


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- **파일 상태값 기반 최종 일관성 확보:** 멘토님 리뷰를 반영하여 업로드 프로세스를 `PENDING` -> `ACTIVE` / `FAILED`로 구조화했습니다. (실패 시 DB 롤백 대신 `FAILED` 상태 기록)
- **고아 파일 정리 스케줄러 추가:** 매일 새벽 3시에 `FAILED` 상태로 남은 더미 파일과 DB 데이터를 자동 삭제하는 `FileCleanupScheduler`를 구현했습니다.
  - *Note:* 스케줄러 작동 시 일반 조회 메서드의 `ACTIVE` 검증 로직과 충돌하지 않도록, 스케줄러 전용 강제 삭제 로직(`deleteFailedFile`)을 별도로 구현하였습니다.
- **백업 관리(`saveInternalData`) 트랜잭션 최적화:** 백업 로직의 독립성을 위해 `REQUIRES_NEW`를 적용하고, 예외 발생 시에도 `FAILED` 상태가 기록되도록 `noRollbackFor`를 설정했습니다.
- **직원 정보 관리(`deleteFile`) 로직 단순화:** 복잡한 `afterCommit` 동기화 코드를 제거하고, DB 삭제 후 물리 파일을 삭제하는 직관적인 순차 구조로 변경했습니다.

## 🔗 관련 이슈
- Resolves: #이슈번호

## 🤔 리뷰어에게 부탁할 사항
- **기존 `cleanupDummyFile` 삭제 관련:** 예외 발생 시 로컬 파일을 지우려던 `cleanupDummyFile` 메서드는 삭제했습니다! 대신 예외 시 `FAILED` 상태만 남기고, **`FileCleanupScheduler`를 추가해 고아 파일을 청소**하도록 변경했습니다. 파일 관련 삭제는 deleteFile 메서드만 사용하시면 됩니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 파일 상태 추적 시스템 도입 (보류 중, 활성, 실패 상태)
* 실패한 파일 자동 정리 스케줄러 추가 (매일 새벽 3시 자동 실행)

## 개선 사항
* 활성 파일에 대한 접근 제어 강화
* 파일 생명주기 및 오류 처리 메커니즘 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->