### PR TITLE
백업 실패 상태 시 파일 삭제 메서드 변경

### DIFF
--- a/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
+++ b/src/main/java/com/sb11/hr_bank/domain/backup/service/BasicBackupService.java
@@ -149,7 +149,7 @@ public class BasicBackupService implements BackupService {
 
       // 백업 최종 실패 시 CSV파일이 남아있을 경우 삭제
       if (csvFile != null) {
-        fileService.cleanupDummyFile(csvFile.getId());
+        fileService.deleteFile(csvFile.getId());
       }
       return BackupResponse.from(failed);
     }


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- 백업 실패 상태 시 csv파일이 존재할 경우 cleanupDummyFile 대신 deleteFile 메서드를 사용하여 해당 파일을 삭제하도록 개선하였습니다.

## 🔗 관련 이슈
- Resolves: #이슈번호

## 🤔 리뷰어에게 부탁할 사항
- File 도메인 담당 지성님의 PR을 확인(cleanupDummyFile이 삭제)하여 deleteFile 메서드로 교체하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 백업 실패 시 CSV 파일 정리 프로세스가 개선되었습니다. 파일 삭제 작업이 더욱 안정적으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->