### PR TITLE
chore: DB 초기화 스크립트 내 file_entities status 컬럼 및 제약조건 추가

### DIFF
--- a/src/main/resources/v1.0.0_hr_bank.sql
+++ b/src/main/resources/v1.0.0_hr_bank.sql
@@ -16,8 +16,8 @@ CREATE TABLE IF NOT EXISTS file_entities
     created_at   TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
     name         VARCHAR(200)                          NOT NULL,
     content_type VARCHAR(30)                           NOT NULL,
-    size         BIGINT                                NOT NULL
-
+    size         BIGINT                                NOT NULL,
+    status       VARCHAR(20) DEFAULT 'PENDING' NOT NULL
     );
 
 CREATE TABLE IF NOT EXISTS employees
@@ -87,9 +87,6 @@ CREATE TABLE IF NOT EXISTS backups
     FOREIGN KEY (file_id) REFERENCES file_entities (id) ON DELETE SET NULL
 
     );
-
-ALTER TABLE file_entities
-    ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'PENDING';
 
 
 

--- a/src/main/resources/v1.0.0_hr_bank.sql
+++ b/src/main/resources/v1.0.0_hr_bank.sql
@@ -88,6 +88,11 @@ CREATE TABLE IF NOT EXISTS backups
 
     );
 
+ALTER TABLE file_entities
+    ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'PENDING';
+
+
+
 
 
 

--- a/src/main/resources/v1.0.0_hr_bank.sql
+++ b/src/main/resources/v1.0.0_hr_bank.sql
@@ -18,6 +18,8 @@ CREATE TABLE IF NOT EXISTS file_entities
     content_type VARCHAR(30)                           NOT NULL,
     size         BIGINT                                NOT NULL,
     status       VARCHAR(20) DEFAULT 'PENDING' NOT NULL
+
+    CHECK ( status IN ('PENDING', 'ACTIVE', 'FAILED') )
     );
 
 CREATE TABLE IF NOT EXISTS employees

--- a/src/main/resources/v1.0.0_hr_bank.sql
+++ b/src/main/resources/v1.0.0_hr_bank.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS file_entities
     name         VARCHAR(200)                          NOT NULL,
     content_type VARCHAR(30)                           NOT NULL,
     size         BIGINT                                NOT NULL,
-    status       VARCHAR(20) DEFAULT 'PENDING' NOT NULL
+    status       VARCHAR(20) DEFAULT 'PENDING' NOT NULL,
 
     CHECK ( status IN ('PENDING', 'ACTIVE', 'FAILED') )
     );


### PR DESCRIPTION
## 🛠 어떤 작업을 하셨나요?
- **데이터 무결성 제약조건 추가:** `file_entities` 테이블에 `FileStatus` 이넘(Enum) 값과 동일한 값만 들어가도록 CHECK 제약조건 추가

## 🔗 관련 이슈
- Resolves: #이슈번호

## 🤔 리뷰어에게 부탁할 사항
**로컬 DB 동기화:** 초기화 스크립트가 수정되었으니, 로컬 DB의 `file_entities` 테이블을 DROP 하고 다시 생성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 파일 엔티티에 상태 추적이 추가되었습니다. 각 파일의 처리 상태를 대기(PENDING), 활성(ACTIVE), 실패(FAILED)로 구분해 관리할 수 있으며, 새로 생성된 파일은 기본적으로 대기(PENDING) 상태로 설정됩니다. 상태 값은 지정된 세 가지 값으로만 제한됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->